### PR TITLE
ENH: Added QuantileTransformer

### DIFF
--- a/daskml/preprocessing/__init__.py
+++ b/daskml/preprocessing/__init__.py
@@ -1,4 +1,7 @@
+"""Utilties for Preprocessing data.
+"""
 from .data import (  # noqa
     StandardScaler,
-    MinMaxScaler
+    MinMaxScaler,
+    QuantileTransformer,
 )

--- a/daskml/preprocessing/data.py
+++ b/daskml/preprocessing/data.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import multiprocessing
 
 import dask.array as da
 import dask.dataframe as dd
@@ -135,9 +136,8 @@ class QuantileTransformer(skdata.QuantileTransformer):
         if isinstance(X, (pd.DataFrame, dd.DataFrame)):
             X = X.values
         if isinstance(X, np.ndarray):
-            # TODO: What should the package policy be on inferring
-            # chunksizes?
-            X = da.from_array(X, chunks=10000)
+            C = len(X) // multiprocessing.cpu_count()
+            X = da.from_array(X, chunks=C)
 
         rng = check_random_state(self.random_state)
         # TODO: non-float dtypes?

--- a/daskml/preprocessing/data.py
+++ b/daskml/preprocessing/data.py
@@ -123,6 +123,14 @@ class MinMaxScaler(skdata.MinMaxScaler):
 
 
 class QuantileTransformer(skdata.QuantileTransformer):
+    """Transforms features using quantile information.
+
+    This implementation differs from the scikit-learn implementation
+    by using approximate quantiles. The scikit-learn docstring follows.
+    """
+    __doc__ = __doc__ + '\n'.join(
+        skdata.QuantileTransformer.__doc__.split("\n")[1:])
+
     def _check_inputs(self, X, accept_sparse_negative=False):
         if isinstance(X, (pd.DataFrame, dd.DataFrame)):
             X = X.values

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -47,14 +47,11 @@ API Reference
 :mod:`daskml.preprocessing`: Preprocessing Data
 ===============================================
 
-
 .. automodule:: daskml.preprocessing
 
 .. currentmodule:: daskml
 
 .. autosummary::
-   :no-members:
-   :no-inherited-members:
 
    preprocessing.StandardScaler
    preprocessing.MinMaxScaler

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -42,3 +42,20 @@ API Reference
 
    cluster.KMeans
    cluster.BigMiniBatchKMeans
+
+
+:mod:`daskml.preprocessing`: Preprocessing Data
+===============================================
+
+
+.. automodule:: daskml.preprocessing
+
+.. currentmodule:: daskml
+
+.. autosummary::
+   :no-members:
+   :no-inherited-members:
+
+   preprocessing.StandardScaler
+   preprocessing.MinMaxScaler
+   preprocessing.QuantileTransformer

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -1,14 +1,15 @@
-from daskml.datasets import make_classification
-from sklearn.preprocessing import StandardScaler as StandardScaler_
-from sklearn.preprocessing import MinMaxScaler as MinMaxScaler_
-from daskml.preprocessing import StandardScaler
-from daskml.preprocessing import MinMaxScaler
+import pytest
+import sklearn.preprocessing as spp
 
+import dask.array as da
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
 from dask.array.utils import assert_eq as assert_eq_ar
 from dask.array.utils import assert_eq as assert_eq_df
 
+import daskml.preprocessing as dpp
+from daskml.datasets import make_classification
 from daskml.utils import assert_estimator_equal
 
 
@@ -20,49 +21,49 @@ df2 = dd.from_pandas(pd.DataFrame(5*[range(42)]).T.rename(columns=str),
 
 class TestStandardScaler(object):
     def test_basic(self):
-        a = StandardScaler()
-        b = StandardScaler_()
+        a = dpp.StandardScaler()
+        b = spp.StandardScaler()
 
         a.fit(X)
         b.fit(X.compute())
         assert_estimator_equal(a, b)
 
     def test_inverse_transform(self):
-        a = StandardScaler()
+        a = dpp.StandardScaler()
         assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
                      X.compute())
 
 
 class TestMinMaxScaler(object):
     def test_basic(self):
-        a = MinMaxScaler()
-        b = MinMaxScaler_()
+        a = dpp.MinMaxScaler()
+        b = spp.MinMaxScaler()
 
         a.fit(X)
         b.fit(X.compute())
         assert_estimator_equal(a, b, exclude='n_samples_seen_')
 
     def test_inverse_transform(self):
-        a = MinMaxScaler()
+        a = dpp.MinMaxScaler()
         assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
                      X.compute())
 
     def test_df_inverse_transform(self):
         mask = ["3", "4"]
-        a = MinMaxScaler(columns=mask)
+        a = dpp.MinMaxScaler(columns=mask)
         assert_eq_df(a.inverse_transform(a.fit_transform(df2)).compute(),
                      df2.compute())
 
     def test_df_values(self):
-        a = MinMaxScaler()
+        a = dpp.MinMaxScaler()
         assert_eq_ar(a.fit_transform(X).compute(),
                      a.fit_transform(df).compute().as_matrix())
 
     def test_df_column_slice(self):
         mask = ["3", "4"]
         mask_ix = [mask.index(x) for x in mask]
-        a = MinMaxScaler(columns=mask)
-        b = MinMaxScaler_()
+        a = dpp.MinMaxScaler(columns=mask)
+        b = spp.MinMaxScaler()
 
         dfa = a.fit_transform(df2).compute()
         mxb = b.fit_transform(df2.compute())
@@ -71,3 +72,36 @@ class TestMinMaxScaler(object):
         assert_eq_df(dfa[mask].as_matrix(), mxb[:, mask_ix])
         assert_eq_df(dfa.drop(mask, axis=1),
                      df2.drop(mask, axis=1).compute())
+
+
+class TestQuantileTransformer(object):
+
+    def test_basic(self):
+        rs = da.random.RandomState(0)
+        a = dpp.QuantileTransformer()
+        b = spp.QuantileTransformer()
+
+        X = rs.uniform(size=(100, 3), chunks=50)
+        a.fit(X)
+        b.fit(X)
+        assert_estimator_equal(a, b, atol=.02)
+
+        # set the quantiles, so that from here out, we're exact
+        a.quantiles_ = b.quantiles_
+        assert_eq_ar(a.transform(X), b.transform(X))
+        assert_eq_ar(X, a.inverse_transform(a.transform(X)))
+
+    @pytest.mark.parametrize('type_, kwargs', [
+        (np.array, {}),
+        (da.from_array, {'chunks': 10}),
+        (pd.DataFrame, {'columns': ['a', 'b', 'c']}),
+        (dd.from_array, {"columns": ['a', 'b', 'c']}),
+    ]
+    )
+    def test_types(self, type_, kwargs):
+        X = np.random.uniform(size=(20, 3))
+        dX = type_(X, **kwargs)
+        qt = spp.QuantileTransformer()
+        qt.fit(X)
+        dqt = dpp.QuantileTransformer()
+        dqt.fit(dX)


### PR DESCRIPTION
This mimics the scikit-learn implementation. The primary difference is that our
version uses *apporiximate* quantiles. I suspect this is a good default for
daskml. It'd be nice to implement an exact version as well, though I'll wait for
interest from users first.

Benchmark:

```python
In [1]: import numpy as np
   ...: import dask.array as da
   ...:
   ...: import sklearn.preprocessing as pp
   ...: import daskml.preprocessing as dp
   ...:
   ...: X = da.random.random(size=(10_000_000, 10), chunks=1_000_000)
   ...: x = X.compute()
   ...:
   ...: qt = pp.QuantileTransformer()
   ...: dqt = dp.QuantileTransformer()
   ...:

In [2]: %time qt.fit(x)
CPU times: user 5.92 s, sys: 961 ms, total: 6.88 s
Wall time: 7.01 s
Out[2]:
QuantileTransformer(copy=True, ignore_implicit_zeros=False, n_quantiles=1000,
          output_distribution='uniform', random_state=None,
          subsample=100000)

In [3]: %time dqt.fit(X)
CPU times: user 9.87 s, sys: 702 ms, total: 10.6 s
Wall time: 1.91 s
Out[3]:
QuantileTransformer(copy=True, ignore_implicit_zeros=False, n_quantiles=1000,
          output_distribution='uniform', random_state=None,
          subsample=100000)

In [4]: %time _ = qt.transform(x)
CPU times: user 23.9 s, sys: 4.52 s, total: 28.4 s
Wall time: 29.1 s

In [5]: %time _ = dqt.transform(X).compute()
CPU times: user 33.3 s, sys: 6.1 s, total: 39.4 s
Wall time: 8.4 s
```

I haven't profiled how much of that is due to parallelism vs. approximate
quantiles.

I also want to look a bit more closely at the difference in
quantiles (presumably due to using approximate quantiles). The maximum
difference is just below 0.02 on the test dataset.