### PR TITLE
PEF: Nogil for _centers_dense

### DIFF
--- a/dask_ml/cluster/_k_means.pyx
+++ b/dask_ml/cluster/_k_means.pyx
@@ -69,9 +69,10 @@ def _centers_dense(np.ndarray[floating, ndim=2] X,
         centers = np.zeros((n_clusters, n_features), dtype=np.float64)
 
 
-    # TODO: think about empty clusters
-    for i in range(n_samples):
-        for j in range(n_features):
-            centers[labels[i], j] += X[i, j]
+    with nogil:
+        # TODO: think about empty clusters
+        for i in range(n_samples):
+            for j in range(n_features):
+                centers[labels[i], j] += X[i, j]
 
     return centers


### PR DESCRIPTION
Setup:

```python
import numpy as np
from pandas.util.testing import test_parallel

from dask_ml.cluster.k_means import _centers_dense

class KMeansBench:
    goal_time = 0.5

    def setup(self):
        rng = np.random.RandomState(0)
        n_samples = 1000000
        n_features = 30
        n_clusters = 15
        X = rng.uniform(size=(n_samples, n_features)).astype('f4')
        labels = rng.randint(0, n_clusters, size=n_samples).astype('i4')
        distances = np.empty(shape=(n_samples,), dtype='f4')
        self.X = X
        self.labels = labels
        self.distances = distances
        self.n_clusters = n_clusters

    @test_parallel(num_threads=4)
    def time_centers_dense(self):
        _centers_dense(self.X, self.labels, self.n_clusters, self.distances)

bench = KMeansBench()
bench.setup()
```

Master:

```python
%timeit bench.time_centers_dense()
81 ms ± 792 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Head:

```python
%timeit bench.time_centers_dense()
24.9 ms ± 1.61 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```