### PR TITLE
Use relative path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages, Extension
 from Cython.Build import cythonize
 import numpy as np
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = os.path.dirname(__file__)
 
 # Get the long description from the README file
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:


### PR DESCRIPTION
One of my absolute paths was leaking into the SOURCES.txt, causing conda-build to fail. I think this will remedy the problem.

xref: https://github.com/conda-forge/staged-recipes/pull/4229 and https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.18080/job/ad1n0ghbpabrk0c9