### PR TITLE
Refer to dask_ml over dask_glm in docs

### DIFF
--- a/dask_ml/datasets.py
+++ b/dask_ml/datasets.py
@@ -70,7 +70,7 @@ def make_counts(n_samples=1000, n_features=100, n_informative=2, scale=1.0,
 
     Examples
     --------
-    >>> X, y = make_classification()
+    >>> X, y = make_counts()
     """
     X = da.random.normal(0, 1, size=(n_samples, n_features),
                          chunks=(chunks, n_features))

--- a/docs/source/glm.rst
+++ b/docs/source/glm.rst
@@ -24,8 +24,8 @@ Example
 
 .. code-block:: python
 
-   >>> from dask_glm.estimators import LogisticRegression
-   >>> from dask_glm.datasets import make_classification
+   >>> from dask_ml.linear_model import LogisticRegression
+   >>> from dask_ml.datasets import make_classification
    >>> X, y = make_classification()
    >>> lr = LogisticRegression()
    >>> lr.fit(X, y)


### PR DESCRIPTION
Also, I found that this example failed:

```python
   >>> from dask_ml.linear_model import LogisticRegression
   >>> from dask_ml.datasets import make_classification
   >>> X, y = make_classification()
   >>> lr = LogisticRegression()
   >>> lr.fit(X, y)
```

Chunks wasn't available in the `_wrap_maker` function, presumably because I didn't provide it as a keyword to `make_classification`.  Is this a requirement?  If so, how should I adjust the example?