### PR TITLE
API: Have concrete values for fitted attributes

### DIFF
--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -21,9 +21,9 @@ def slice_columns(X, columns):
 
 def handle_zeros_in_scale(scale):
     scale = scale.copy()
-    if isinstance(scale, da.Array):
+    if isinstance(scale, (np.ndarray, da.Array)):
         scale[scale == 0.0] = 1.0
-    elif isinstance(scale, dd.Series):
+    elif isinstance(scale, (pd.Series, dd.Series)):
         scale = scale.where(scale != 0, 1)
     return scale
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,12 @@
+Changelog
+=========
+
+Version 0.2.0
+~~~~~~~~~~~~~
+
+API Changes
+-----------
+
+- Changed the fitted attributes on ``MinMaxScaler`` and ``StandardScaler`` to be
+  concrete NumPy or pandas objects, rather than persisted dask objects
+  (:issue:`75`).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -191,3 +191,9 @@ def generate_example_rst(app, what, name, obj, options, lines):
 
 def setup(app):
     app.connect('autodoc-process-docstring', generate_example_rst)
+
+
+extlinks = {
+    'issue': ('https://github.com/dask/dask/issues/%s', 'GH#'),
+    'pr': ('https://github.com/dask/dask/pull/%s', 'GH#')
+}

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -73,7 +73,8 @@ We have some additional decisions to make in the dask context. Ideally
 
 3. If possible, transformers should accept a ``columns`` keyword to limit the
    transformation to just those columns, while passing through other columns
-   untouched.
+   untouched. ``inverse_transform`` should behave similarly (ignoring other
+   columns) so that ``inverse_transform(transform(X))`` equals ``X``.
 4. Methods returning arrays (like ``.transform``, ``.predict``), should return
    the same type as the input. So if a ``dask.array`` is passed in, a
    ``dask.array`` with the same chunks should be returned.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ familiar NumPy, Pandas, and Scikit-Learn APIs.
    :maxdepth: 2
    :caption: Contents:
 
+   changelog.rst
    install.rst
    contributing.rst
    hyper-parameter-search.rst

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -11,14 +11,15 @@ import pandas.util.testing as tm
 from pandas.api.types import is_categorical_dtype, is_object_dtype
 from dask import compute
 from dask.array.utils import assert_eq as assert_eq_ar
-from dask.array.utils import assert_eq as assert_eq_df
+from dask.dataframe.utils import assert_eq as assert_eq_df
 
 import dask_ml.preprocessing as dpp
 from dask_ml.datasets import make_classification
 from dask_ml.utils import assert_estimator_equal
+from dask_ml.preprocessing.data import handle_zeros_in_scale
 
 
-X, y = make_classification(chunks=2)
+X, y = make_classification(chunks=50)
 df = X.to_dask_dataframe().rename(columns=str)
 df2 = dd.from_pandas(pd.DataFrame(5 * [range(42)]).T.rename(columns=str),
                      npartitions=5)
@@ -64,6 +65,7 @@ class TestMinMaxScaler(object):
         assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
                      X.compute())
 
+    @pytest.mark.xfail(reason="removed columns")
     def test_df_inverse_transform(self):
         mask = ["3", "4"]
         a = dpp.MinMaxScaler(columns=mask)
@@ -71,10 +73,23 @@ class TestMinMaxScaler(object):
                      df2.compute())
 
     def test_df_values(self):
-        a = dpp.MinMaxScaler()
-        assert_eq_ar(a.fit_transform(X).compute(),
-                     a.fit_transform(df).compute().as_matrix())
+        est1 = dpp.MinMaxScaler()
+        est2 = dpp.MinMaxScaler()
 
+        result_ar = est1.fit_transform(X)
+        result_df = est2.fit_transform(df)
+
+        for attr in ['data_min_', 'data_max_', 'data_range_',
+                     'scale_', 'min_']:
+            assert_eq_ar(getattr(est1, attr), getattr(est2, attr).values)
+
+        assert_eq_ar(est1.transform(X), est2.transform(X))
+        assert_eq_ar(est1.transform(df).values, est2.transform(X))
+        assert_eq_ar(est1.transform(X), est2.transform(df).values)
+
+        assert_eq_ar(result_ar, result_df.values)
+
+    @pytest.mark.xfail(reason="removed columns")
     def test_df_column_slice(self):
         mask = ["3", "4"]
         mask_ix = [mask.index(x) for x in mask]
@@ -85,7 +100,7 @@ class TestMinMaxScaler(object):
         mxb = b.fit_transform(df2.compute())
 
         assert isinstance(dfa, pd.DataFrame)
-        assert_eq_df(dfa[mask].as_matrix(), mxb[:, mask_ix])
+        assert_eq_ar(dfa[mask].values, mxb[:, mask_ix])
         assert_eq_df(dfa.drop(mask, axis=1),
                      df2.drop(mask, axis=1).compute())
 
@@ -249,3 +264,25 @@ class TestDummyEncoder:
         with pytest.raises(ValueError) as rec:
             de.transform(dummy.drop("B", axis='columns'))
         assert rec.match("Columns of 'X' do not match the training")
+
+
+def test_handle_zeros_in_scale():
+    x = np.array([1, 2, 3, 0], dtype='f8')
+    expected = np.array([1, 2, 3, 1], dtype='f8')
+    result = handle_zeros_in_scale(x)
+    np.testing.assert_array_equal(result, expected)
+
+    x = pd.Series(x)
+    expected = pd.Series(expected)
+    result = handle_zeros_in_scale(x)
+    tm.assert_series_equal(result, expected)
+
+    x = da.from_array(x.values, chunks=2)
+    expected = expected.values
+    result = handle_zeros_in_scale(x)
+    assert_eq_ar(result, expected)
+
+    x = dd.from_dask_array(x)
+    expected = pd.Series(expected)
+    result = handle_zeros_in_scale(x)
+    assert_eq_df(result, expected)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -264,25 +264,3 @@ class TestDummyEncoder:
         with pytest.raises(ValueError) as rec:
             de.transform(dummy.drop("B", axis='columns'))
         assert rec.match("Columns of 'X' do not match the training")
-
-
-def test_handle_zeros_in_scale():
-    x = np.array([1, 2, 3, 0], dtype='f8')
-    expected = np.array([1, 2, 3, 1], dtype='f8')
-    result = handle_zeros_in_scale(x)
-    np.testing.assert_array_equal(result, expected)
-
-    x = pd.Series(x)
-    expected = pd.Series(expected)
-    result = handle_zeros_in_scale(x)
-    tm.assert_series_equal(result, expected)
-
-    x = da.from_array(x.values, chunks=2)
-    expected = expected.values
-    result = handle_zeros_in_scale(x)
-    assert_eq_ar(result, expected)
-
-    x = dd.from_dask_array(x)
-    expected = pd.Series(expected)
-    result = handle_zeros_in_scale(x)
-    assert_eq_df(result, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import inspect
 
 import pytest
 import pandas as pd
+import pandas.util.testing as tm
 import six
 import numpy as np
 import dask.dataframe as dd
@@ -41,6 +42,27 @@ def test_handle_zeros_in_scale():
 
     assert list(s2.compute()) == [1, 1, 2, 3, 1]
     assert list(a2.compute()) == [1, 1, 2, 3, 1]
+
+    x = np.array([1, 2, 3, 0], dtype='f8')
+    expected = np.array([1, 2, 3, 1], dtype='f8')
+    result = handle_zeros_in_scale(x)
+    np.testing.assert_array_equal(result, expected)
+
+    x = pd.Series(x)
+    expected = pd.Series(expected)
+    result = handle_zeros_in_scale(x)
+    tm.assert_series_equal(result, expected)
+
+    x = da.from_array(x.values, chunks=2)
+    expected = expected.values
+    result = handle_zeros_in_scale(x)
+    assert_eq_ar(result, expected)
+
+    x = dd.from_dask_array(x)
+    expected = pd.Series(expected)
+    result = handle_zeros_in_scale(x)
+    assert_eq_df(result, expected)
+
 
 
 def test_assert_estimator_passes():


### PR DESCRIPTION
Closes #75 

I've (temporarily) removed the `columns` argument. I'm going to come back with another PR handling it generically for many transformers.