### PR TITLE
BLD: Added pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm", "cython"]

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,9 @@ import os
 from codecs import open
 
 from setuptools import setup, find_packages, Extension
-from Cython.Build import cythonize
 import numpy as np
-
 here = os.path.dirname(__file__)
+
 
 # Get the long description from the README file
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
@@ -31,7 +30,6 @@ extra_requires = {
     'complete': complete_requires,
 }
 
-# C Extensions
 extensions = [
     Extension(
         "dask_ml.cluster._k_means",
@@ -39,6 +37,14 @@ extensions = [
         include_dirs=[np.get_include()],
     ),
 ]
+
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    pass
+else:
+    extensions = cythonize(extensions)
+
 
 setup(
     name='dask-ml',
@@ -67,5 +73,5 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=install_requires,
     extras_require=extra_requires,
-    ext_modules=cythonize(extensions),
+    ext_modules=extensions,
 )


### PR DESCRIPTION
Adds a pyproject.toml to allow building from source without Cython already in the environment.

This relies on pip>=10.0, which isn't released yet, though it looks like they're close. I'd rather just merge this PR and instruct users to install Cython manually before installing dask-ml, rather than complicate our setup.py further. Once pip 10 is out and supporting PEP-518, things should work fine (and it does work for me locally with pip 10).

Closes #92 

cc @metasyn 