### PR TITLE
ENH: Ordinal (integer) Encoding

### DIFF
--- a/dask_ml/preprocessing/__init__.py
+++ b/dask_ml/preprocessing/__init__.py
@@ -7,4 +7,5 @@ from .data import (  # noqa
     QuantileTransformer,
     Categorizer,
     DummyEncoder,
+    OrdinalEncoder,
 )

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -703,7 +703,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
     >>> enc.fit_transform(dd.from_pandas(data, 2))
     Dask DataFrame Structure:
                        A     B
-    npartitions=2             
+    npartitions=2
     0              int64  int8
     2                ...   ...
     3                ...   ...

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -640,3 +640,217 @@ class DummyEncoder(BaseEstimator, TransformerMixin):
         else:
             df = pd.concat([non_cat] + cats, axis=1)[self.columns_]
         return df
+
+
+class OrdinalEncoder(BaseEstimator, TransformerMixin):
+    """Ordinal (integer) encode categorical columns.
+
+    Parameters
+    ----------
+    columns : sequence, optional
+        The columns to dummy encode. Must be categorical dtype.
+        Dummy encodes all categorical dtype columns by default.
+
+    Attributes
+    ----------
+    columns_ : Index
+        The columns in the training data before dummy encoding
+
+    transformed_columns_ : Index
+        The columns in the training data after dummy encoding
+
+    categorical_columns_ : Index
+        The categorical columns in the training data
+
+    noncategorical_columns_ : Index
+        The rest of the columns in the training data
+
+    categorical_blocks_ : dict
+        Mapping from column names to slice objects. The slices
+        represent the positions in the transformed array that the
+        categorical column ends up at
+
+    dtypes_ : dict
+        Dictionary mapping column name to either
+
+        * instances of CategoricalDtype (pandas >= 0.21.0)
+        * tuples of (categories, ordered)
+
+    Notes
+    -----
+    This transformer only applies to dask and pandas DataFrames. For dask
+    DataFrames, all of your categoricals should be known.
+
+    The inverse transformation can be used on a dataframe or array.
+
+    Examples
+    --------
+    >>> data = pd.DataFrame({"A": [1, 2, 3, 4],
+    ...                      "B": pd.Categorical(['a', 'a', 'a', 'b'])})
+    >>> de = DummyEncoder()
+    >>> trn = de.fit_transform(data)
+    >>> trn
+    A  B_a  B_b
+    0  1    1    0
+    1  2    1    0
+    2  3    1    0
+    3  4    0    1
+
+    >>> de.columns_
+    Index(['A', 'B'], dtype='object')
+
+    >>> de.non_categorical_columns_
+    Index(['A'], dtype='object')
+
+    >>> de.categorical_columns_
+    Index(['B'], dtype='object')
+
+    >>> de.dtypes_
+    {'B': CategoricalDtype(categories=['a', 'b'], ordered=False)}
+
+    >>> de.categorical_blocks_
+    {'B': slice(1, 3, None)}
+
+    >>> de.fit_transform(dd.from_pandas(data, 2))
+    Dask DataFrame Structure:
+                    A    B_a    B_b
+    npartitions=2
+    0              int64  uint8  uint8
+    2                ...    ...    ...
+    3                ...    ...    ...
+    Dask Name: get_dummies, 4 tasks
+    """
+    def __init__(self, columns=None):
+        self.columns = columns
+
+    def fit(self, X, y=None):
+        """Determine the categorical columns to be dummy encoded.
+
+        Parameters
+        ----------
+        X : pandas.DataFrame or dask.dataframe.DataFrame
+        y : ignored
+
+        Returns
+        -------
+        self
+        """
+        self.columns_ = X.columns
+        columns = self.columns
+        if columns is None:
+            columns = X.select_dtypes(include=['category']).columns
+        else:
+            for column in columns:
+                assert is_categorical_dtype(X[column]), "Must be categorical"
+
+        self.categorical_columns_ = columns
+        self.non_categorical_columns_ = X.columns.drop(
+            self.categorical_columns_)
+
+        if _HAS_CTD:
+            self.dtypes_ = {col: X[col].dtype
+                            for col in self.categorical_columns_}
+        else:
+            self.dtypes_ = {
+                col: (X[col].cat.categories, X[col].cat.ordered)
+                for col in self.categorical_columns_
+            }
+
+        return self
+
+    def transform(self, X, y=None):
+        """Ordinal encode the categorical columns in X
+
+        Parameters
+        ----------
+        X : pd.DataFrame or dd.DataFrame
+        y : ignored
+
+        Returns
+        -------
+        transformed : pd.DataFrame or dd.DataFrame
+            Same type as the input
+        """
+        if not X.columns.equals(self.columns_):
+            raise ValueError("Columns of 'X' do not match the training "
+                             "columns. Got {!r}, expected {!r}".format(
+                                 X.columns, self.columns
+                             ))
+        if not isinstance(X, (pd.DataFrame, dd.DataFrame)):
+            raise TypeError("Unexpected type {}".format(type(X)))
+
+        X = X.copy()
+        for col in self.categorical_columns_:
+            X[col] = X[col].cat.codes
+        return X
+
+    def inverse_transform(self, X):
+        """Inverse ordinal-encode the columns in `X`
+
+        Parameters
+        ----------
+        X : array or dataframe
+            Either the NumPy, dask, or pandas version
+
+        Returns
+        -------
+        data : DataFrame
+            Dask array or dataframe will return a Dask DataFrame.
+            Numpy array or pandas dataframe will return a pandas DataFrame
+        """
+        if isinstance(X, np.ndarray):
+            X = pd.DataFrame(X, columns=self.columns_)
+
+        elif isinstance(X, da.Array):
+            # later on we concat(..., axis=1), which requires
+            # known divisions. Suboptimal, but I think unavoidable.
+            unknown = np.isnan(X.chunks[0]).any()
+            if unknown:
+                lengths = da.atop(len, 'i', X[:, 0],
+                                  'i', dtype='i8').compute()
+                X = X.copy()
+                chunks = (tuple(lengths), X.chunks[1])
+                X._chunks = chunks
+
+            X = dd.from_dask_array(X, columns=self.columns_)
+
+        big = isinstance(X, dd.DataFrame)
+
+        if big:
+            chunks = np.array(X.divisions)
+            chunks[-1] = chunks[-1] + 1
+            chunks = tuple(chunks[1:] - chunks[:-1])
+
+        X = X.copy()
+        for col in self.categorical_columns_:
+            if _HAS_CTD:
+                dtype = self.dtypes_[col]
+                categories, ordered = dtype.categories, dtype.ordered
+            else:
+                categories, ordered = self.dtypes_[col]
+
+            # use .values to avoid warning from pandas
+            codes = X[col].values
+
+            if big:
+                # dask
+                codes._chunks = (chunks,)
+                # Need a Categorical.from_codes for dask
+                series = (dd.from_dask_array(codes, columns=col)
+                          .astype('category')
+                          .cat.set_categories(np.arange(len(categories)),
+                                              ordered=ordered)
+                          .cat.rename_categories(categories))
+                # Bug in pandas <= 0.20.3 lost name
+                if series.name is None:
+                    series.name = col
+                series.divisions = X.divisions
+            else:
+                # pandas
+                series = pd.Series(pd.Categorical.from_codes(
+                    codes, categories, ordered=ordered
+                ), name=col)
+
+            X[col] = series
+
+        return X

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -648,27 +648,19 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     columns : sequence, optional
-        The columns to dummy encode. Must be categorical dtype.
-        Dummy encodes all categorical dtype columns by default.
+        The columns to encode. Must be categorical dtype.
+        Encodes all categorical dtype columns by default.
 
     Attributes
     ----------
     columns_ : Index
-        The columns in the training data before dummy encoding
-
-    transformed_columns_ : Index
-        The columns in the training data after dummy encoding
+        The columns in the training data before/after encoding
 
     categorical_columns_ : Index
         The categorical columns in the training data
 
     noncategorical_columns_ : Index
         The rest of the columns in the training data
-
-    categorical_blocks_ : dict
-        Mapping from column names to slice objects. The slices
-        represent the positions in the transformed array that the
-        categorical column ends up at
 
     dtypes_ : dict
         Dictionary mapping column name to either
@@ -687,44 +679,42 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
     --------
     >>> data = pd.DataFrame({"A": [1, 2, 3, 4],
     ...                      "B": pd.Categorical(['a', 'a', 'a', 'b'])})
-    >>> de = DummyEncoder()
-    >>> trn = de.fit_transform(data)
+    >>> enc = OrdinalEncoder()
+    >>> trn = enc.fit_transform(data)
     >>> trn
-    A  B_a  B_b
-    0  1    1    0
-    1  2    1    0
-    2  3    1    0
-    3  4    0    1
+       A  B
+    0  1  0
+    1  2  0
+    2  3  0
+    3  4  1
 
-    >>> de.columns_
+    >>> enc.columns_
     Index(['A', 'B'], dtype='object')
 
-    >>> de.non_categorical_columns_
+    >>> enc.non_categorical_columns_
     Index(['A'], dtype='object')
 
-    >>> de.categorical_columns_
+    >>> enc.categorical_columns_
     Index(['B'], dtype='object')
 
-    >>> de.dtypes_
+    >>> enc.dtypes_
     {'B': CategoricalDtype(categories=['a', 'b'], ordered=False)}
 
-    >>> de.categorical_blocks_
-    {'B': slice(1, 3, None)}
-
-    >>> de.fit_transform(dd.from_pandas(data, 2))
+    >>> enc.fit_transform(dd.from_pandas(data, 2))
     Dask DataFrame Structure:
-                    A    B_a    B_b
-    npartitions=2
-    0              int64  uint8  uint8
-    2                ...    ...    ...
-    3                ...    ...    ...
-    Dask Name: get_dummies, 4 tasks
+                       A     B
+    npartitions=2             
+    0              int64  int8
+    2                ...   ...
+    3                ...   ...
+    Dask Name: assign, 8 tasks
+
     """
     def __init__(self, columns=None):
         self.columns = columns
 
     def fit(self, X, y=None):
-        """Determine the categorical columns to be dummy encoded.
+        """Determine the categorical columns to be encoded.
 
         Parameters
         ----------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Enhancements
 ------------
 
 - Added :meth:`dask_ml.preprocessing.RobustScaler` (:issue:`62`)
+- Added :meth:`dask_ml.preprocessing.OrdinalEncoder` (:issue:`119`)
 
 
 Version 0.4.0

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -116,6 +116,7 @@ a parallel or distributed training any more than the underlying estimator.
    preprocessing.QuantileTransformer
    preprocessing.Categorizer
    preprocessing.DummyEncoder
+   preprocessing.OrdinalEncoder
 
 
 :mod:`dask_ml.tensorflow`: Tensorflow

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -40,6 +40,7 @@ Other transformers are specific to dask-ml.
 
    Categorizer
    DummyEncoder
+   OrdinalEncoder
 
 
 Both :class:`dask_ml.preprocessing.Categorizer` and

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -360,25 +360,28 @@ class TestOrdinalEncoder:
 
         tm.assert_frame_equal(result, df)
 
-    # def test_da(self):
-    #     a = dd.from_pandas(dummy, npartitions=2)
-    #     de = dpp.DummyEncoder()
-    #     result = de.fit_transform(a)
-    #     assert isinstance(result, dd.DataFrame)
+    def test_da(self):
+        a = dd.from_pandas(dummy, npartitions=2)
+        de = dpp.OrdinalEncoder()
+        result = de.fit_transform(a)
+        assert isinstance(result, dd.DataFrame)
 
-    # def test_transform_raises(self):
-    #     de = dpp.DummyEncoder()
-    #     de.fit(dummy)
-    #     with pytest.raises(ValueError) as rec:
-    #         de.transform(dummy.drop("B", axis='columns'))
-    #     assert rec.match("Columns of 'X' do not match the training")
+    def test_transform_raises(self):
+        de = dpp.OrdinalEncoder()
+        de.fit(dummy)
+        with pytest.raises(ValueError) as rec:
+            de.transform(dummy.drop("B", axis='columns'))
+        assert rec.match("Columns of 'X' do not match the training")
 
-    # def test_inverse_transform(self):
-    #     de = dpp.DummyEncoder()
-    #     df = dd.from_pandas(pd.DataFrame({"A": np.arange(10),
-    #                                       "B": pd.Categorical(['a'] * 4 +
-    #                                                           ['b'] * 6)}),
-    #                         npartitions=2)
-    #     de.fit(df)
-    #     assert_eq_df(df, de.inverse_transform(de.transform(df)))
-    #     assert_eq_df(df, de.inverse_transform(de.transform(df).values))
+    def test_inverse_transform(self):
+        enc = dpp.OrdinalEncoder()
+        df = dd.from_pandas(pd.DataFrame({"A": np.arange(10),
+                                          "B": pd.Categorical(['a'] * 4 +
+                                                              ['b'] * 6)}),
+                            npartitions=2)
+        enc.fit(df)
+        assert_eq_df(df, enc.inverse_transform(enc.transform(df)))
+        assert_eq_df(df, enc.inverse_transform(enc.transform(df).compute()))
+        assert_eq_df(df, enc.inverse_transform(enc.transform(df).values))
+        assert_eq_df(df, enc.inverse_transform(
+            enc.transform(df).values.compute()))


### PR DESCRIPTION
This is adding an OrdinalEncoder (or integer encoder) that basically just converts the categorical columns into its integer codes (eg for trees).

There is quite some overlap with the code in DummyEncoder, so I could create a common base class. But first wanted to have something working.