### PR TITLE
[WIP]IID wrappers for scikit-learn

### DIFF
--- a/dask_ml/base.py
+++ b/dask_ml/base.py
@@ -1,9 +1,14 @@
+import inspect
 import os
-import six
 from abc import ABCMeta
 
-import numpy as np
 import dask
+import dask.array as da
+import dask.dataframe as dd
+import dask.delayed
+import numpy as np
+import six
+import sklearn.base
 from dask.array import learn
 
 
@@ -77,6 +82,7 @@ class _BigPartialFitMixin(object):
 
 
 def _copy_partial_doc(cls):
+    """Insert a qualification into the base class' docstring."""
     for base in cls.mro():
         if base.__module__.startswith('sklearn'):
             break
@@ -98,7 +104,168 @@ def _copy_partial_doc(cls):
     return cls
 
 
+def _iid_rewriter(cls):
+    """Insert a qualification into the base class' method's docstring.
+
+    This rewrites for
+
+    * fit
+    * transform
+    * predict
+    * predict_proba
+    """
+    for base in cls.mro():
+        if base.__module__.startswith('sklearn'):
+            break
+
+    fit_tpl = """
+
+    *This class trains only on the first block of a dask array
+    or the first partition of a dask dataframe.*"""
+
+    other_tpl = """
+
+    *This class operates block-wise on dask arrays and partition-wise on
+    dask dataframes.*"""
+
+    for name in ['fit', 'transform', 'predict', 'predict_proba']:
+        method = getattr(base, name, None)
+        if method and method.__doc__:
+            lines = method.__doc__.split(os.linesep)
+            header, rest = lines[0], lines[1:]
+
+            if name == 'fit':
+                insert = fit_tpl
+            else:
+                insert = other_tpl
+
+            doc = '\n'.join([header + insert] + rest)
+            setattr(getattr(base, name), '__doc__', doc)
+
+    return cls
+
+
+class _IIDBaseMixin:
+    # Make a scikit-learn class transparently "work" with dask arrays.
+    # We fit on just the first block / partition.
+    # We transform, predict, etc. block- / partition-wise
+    # Transformer, predict, etc. are implemented elsewhere, since not all
+    # classes implement these methods.
+    def fit(self, X, y=None):
+        X = _first_block(X)
+        y = _first_block(y)
+        X, y = dask.compute(X, y)
+        result = super().fit(X, y)
+
+        # Copy the learned attributes over to self
+        attrs = {k: v for k, v in vars(result).items() if k.endswith('_')}
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+        return self
+
+
+class _PredictMixin:
+    def predict(self, X):
+        predict = super().predict
+
+        if isinstance(X, da.Array):
+            return X.map_blocks(predict, dtype='int', drop_axis=1)
+        elif isinstance(X, dd._Frame):
+            sample = super().predict(X._meta_nonempty)
+            if sample.ndim <= 1:
+                p = ()
+            elif sample.ndim == 1:
+                p = sample.shape[1]
+            else:
+                raise AssertionError
+
+            if isinstance(sample, np.ndarray):
+                blocks = X.to_delayed()
+                arrays = [
+                    da.from_delayed(dask.delayed(predict)(block),
+                                    shape=(np.nan,) + p,
+                                    dtype=sample.dtype)
+                    for block in blocks
+                ]
+                return da.concatenate(arrays)
+            else:
+                return X.map_partitions(super().predict, meta=sample)
+        else:
+            return super().predict(X)
+
+
+class _PredictProbaMixin:
+    def predict_proba(self, X):
+        if isinstance(X, da.Array):
+            # TODO: multiclass
+            return X.map_blocks(super().predict_proba, dtype='float',
+                                chunks=(X.chunks[0], 2))
+        elif isinstance(X, dd._Frame):
+            raise NotImplementedError("Not implemented yet")
+        else:
+            return super().predict_proba(X)
+
+
+class _IIDTransformerMixin:
+    def transform(self, X, y=None):
+        if isinstance(X, da.Array):
+            return X.map_blocks(super().transform, y)
+        elif isinstance(X, dd._Frame):
+            return X.map_partitions(super().transform, y)
+        else:
+            return super().transform(X, y)
+
+
+def _first_block(dask_object):
+    """Extract the first block / partition from a dask object
+    """
+    if isinstance(dask_object, da.Array):
+        if dask_object.ndim > 1 and dask_object.numblocks[-1] != 1:
+            raise NotImplementedError("IID estimators require that the array "
+                                      "blocked only along the first axis. "
+                                      "Rechunk your array before fitting.")
+        return dask_object.to_delayed().flatten()[0]
+
+    if isinstance(dask_object, dd._Frame):
+        return dask_object.get_partition(0)
+
+
+def _make_estimator(parent):
+    bases = [_IIDBaseMixin]
+    if issubclass(parent, sklearn.base.TransformerMixin):
+        bases.append(_IIDTransformerMixin)
+
+    d = {}
+    if hasattr(parent, 'predict'):
+        bases.append(_PredictMixin)
+    if hasattr(parent, 'predict_proba'):
+        bases.append(_PredictProbaMixin)
+
+    bases.append(parent)
+
+    # create the class from our component base classes.
+    cls = type(parent.__name__, tuple(bases), d)
+    # Add our qualifications to the docstirngs
+    cls = _iid_rewriter(cls)
+    # for pickle
+    cls.__module__ = 'dask_ml.iid.' + parent.__module__.split('.')[1]
+    return cls
+
+
+def _find_estimators(module):
+    exclusions = ()
+
+    return [module.__dict__[cls] for cls in module.__all__
+            if inspect.isclass(module.__dict__[cls]) and
+            issubclass(module.__dict__[cls],
+                       sklearn.base.BaseEstimator) and
+            not issubclass(module.__dict__[cls], exclusions)]
+
+
 __all__ = [
     '_BigPartialFitMixin',
     '_copy_partial_doc',
+    '_make_estimator',
+    '_find_estimators',
 ]

--- a/dask_ml/iid/__init__.py
+++ b/dask_ml/iid/__init__.py
@@ -1,0 +1,5 @@
+"""Models for independently and identically distributed data.
+
+These estimators are simple wrappers around scikit-learn's estimators. They are
+valid only if your data are independently and identically distributed (IID).
+"""

--- a/dask_ml/iid/cluster/__init__.py
+++ b/dask_ml/iid/cluster/__init__.py
@@ -1,0 +1,13 @@
+import sklearn.cluster
+import sklearn.cluster.bicluster
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.cluster)
+
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/covariance/__init__.py
+++ b/dask_ml/iid/covariance/__init__.py
@@ -1,0 +1,12 @@
+import sklearn.covariance
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.covariance)
+
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/decomposition/__init__.py
+++ b/dask_ml/iid/decomposition/__init__.py
@@ -1,0 +1,12 @@
+import sklearn.decomposition
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.decomposition)
+
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/ensemble/__init__.py
+++ b/dask_ml/iid/ensemble/__init__.py
@@ -1,0 +1,12 @@
+import sklearn.ensemble
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.ensemble)
+
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/gaussian_process/__init__.py
+++ b/dask_ml/iid/gaussian_process/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.gaussian_process
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.gaussian_process)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/linear_model/__init__.py
+++ b/dask_ml/iid/linear_model/__init__.py
@@ -1,0 +1,12 @@
+import sklearn.linear_model
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.linear_model)
+
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/manifold/__init__.py
+++ b/dask_ml/iid/manifold/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.manifold
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.manifold)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/mixture/__init__.py
+++ b/dask_ml/iid/mixture/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.mixture
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.mixture)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/neighbors/__init__.py
+++ b/dask_ml/iid/neighbors/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.neighbors
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.neighbors)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/neural_network/__init__.py
+++ b/dask_ml/iid/neural_network/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.neural_network
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.neural_network)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/preprocessing/__init__.py
+++ b/dask_ml/iid/preprocessing/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.preprocessing
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.preprocessing)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/semi_supervised/__init__.py
+++ b/dask_ml/iid/semi_supervised/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.semi_supervised
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.semi_supervised)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/svm/__init__.py
+++ b/dask_ml/iid/svm/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.svm
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.svm)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/dask_ml/iid/tree/__init__.py
+++ b/dask_ml/iid/tree/__init__.py
@@ -1,0 +1,11 @@
+import sklearn.tree
+
+from ...base import _make_estimator, _find_estimators
+
+__all__ = []
+_models = _find_estimators(sklearn.tree)
+
+for _model in _models:
+    _name = _model.__name__
+    globals()[_name] = _make_estimator(_model)
+    __all__.append(_name)

--- a/docs/source/iid.rst
+++ b/docs/source/iid.rst
@@ -1,0 +1,86 @@
+Estimators for IID Data
+=======================
+
+.. warning::
+
+   Only the first block or partition of your dask object is used for training.
+
+The ``dask_ml.iid`` sub-package offers *many* estimators for data that are
+independently and identically distributed (IID). The estimators in this
+sub-package are suitable large datasets stored as dask Arrays or DataFrames *if
+your data are IID*.
+
+This sub-package was born out of the observation that
+
+1. Oftentimes, a random sample of the dataset is representative of the whole
+2. Your *learning curve* may have leveled off before you run out of RAM (TODO:
+   link)
+3. It's common to *train* on a small subset of the data and *predict* for a
+   much larger dataset.
+
+The ``dask_ml.iid`` package layout is identical to scikit-learn's. For example,
+we'll import ``RandomForestClassier`` from ``dask_ml.iid.ensemble``.
+
+.. ipython:: python
+
+   from dask_ml.iid.ensemble import RandomForestClassifier
+   from dask_ml.datasets import make_classification
+
+   X, y = make_classification(n_samples=10000, chunks=1000,
+                              random_state=0)
+
+   clf = RandomForestClassifier()
+   clf.fit(X, y)
+
+This has trained on just the first block (1000 samples in this case). But we can
+easily predict for the entire dataset, returning a dask array.
+
+.. ipython:: python
+
+   clf.predict(X)
+   
+IID Data
+''''''''
+
+Informally, data are IID if the order "doesn't matter". That is, if any random
+sample of the data is just as likely to be representative of the whole as any
+other random sample. Many datasets are *not* IID, and so the estimators in this
+sub-packge *will give you biased results*. In particular, time series data are
+often not IID, since there are often correlations between subsequent
+observations in time series (for example, there may be a roughly constant growth
+factor). If your dataset is sorted in any way (say by user ID, or by output
+class) then you should shuffle your data (TODO: using...)
+
+Compared to the scikit-learn implementation, the following methods return dask
+arrays or dataframes, instead of NumPy or pandas versions:
+
+* ``.predict``
+* ``.transform``
+
+The general rule is that a dask collection is returned if the input was a dask
+collection, and the output is large (same length as the input).
+
+Comparison to Incremental Learners
+''''''''''''''''''''''''''''''''''
+
+``dask_ml`` also offers many :ref:<incremental `incremental`>_ estimators.
+There's some overlap between these two styles of estimators. The primary
+difference lies in *which data the estimator is trained on*.
+
+* Incremental estimators are trained on the *entire* dataset, one block or
+  partition at a time
+* IID estimators are trained on *only the first block or partition*.
+
+In general, an incremental estimator will give you a more accurate estimator
+(especially if your data are not IID) but will take longer to train.
+Additionally, only some algorithms can be trained incrementally; there may not
+be an incremental version of the estimator you want to use.
+
+Comparison to other Estimators in dask-ml
+'''''''''''''''''''''''''''''''''''''''''
+
+``dask-ml`` re-implements some estimators from scikit-learn, for example
+``KMeans``, or ``QuantileTransformer``. For these cases, we'd generally
+recommend using the re-implemented version. These have been written specifically
+for dask collections, and so may be better parallelized or tuned for distributed
+computation.

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -1,3 +1,5 @@
+.. _incremental:
+
 Incremental Learning
 ====================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ familiar NumPy, Pandas, and Scikit-Learn APIs.
    preprocessing.rst
    hyper-parameter-search.rst
    glm.rst
+   iid.rst
    incremental.rst
    joblib.rst
    xgboost.rst

--- a/tests/test_iid.py
+++ b/tests/test_iid.py
@@ -1,0 +1,136 @@
+import inspect
+
+import dask.array as da
+import dask.dataframe as dd
+import pytest
+import sklearn.base
+import sklearn.linear_model
+
+from dask_ml.datasets import make_regression, make_classification
+from dask_ml.utils import assert_estimator_equal
+
+import dask_ml.iid.cluster
+import dask_ml.iid.covariance
+import dask_ml.iid.decomposition
+import dask_ml.iid.ensemble
+import dask_ml.iid.gaussian_process
+import dask_ml.iid.linear_model
+import dask_ml.iid.manifold
+import dask_ml.iid.mixture
+import dask_ml.iid.neighbors
+import dask_ml.iid.neural_network
+import dask_ml.iid.preprocessing
+import dask_ml.iid.semi_supervised
+import dask_ml.iid.svm
+import dask_ml.iid.tree
+
+
+skips = {
+    # Deprecated, and doesn't use wraps so no signature
+    'RandomizedLasso',
+    'RandomizedLogisticRegression',
+    'RandomizedPCA',
+    # 'errors' don't match
+    'DictionaryLearning',
+    # Different __init__
+    'SparseCoder',
+    # Abstract
+    'BaseEnsemble',  # TODO: see if you can filter these. Why are they in all?
+    # TODO
+    'VotingClassifier',
+    # Bug in scikit-learn?
+}
+
+
+@pytest.fixture(params=(
+    dask_ml.iid.cluster._models +
+    dask_ml.iid.covariance._models +
+    dask_ml.iid.decomposition._models +
+    dask_ml.iid.ensemble._models +
+    dask_ml.iid.gaussian_process._models +
+    dask_ml.iid.linear_model._models +
+    dask_ml.iid.manifold._models +
+    dask_ml.iid.mixture._models +
+    dask_ml.iid.neighbors._models +
+    dask_ml.iid.neural_network._models +
+    dask_ml.iid.preprocessing._models +
+    dask_ml.iid.semi_supervised._models +
+    dask_ml.iid.svm._models +
+    dask_ml.iid.tree._models
+))
+def model(request):
+    return request.param
+
+
+def test_linear_regression():
+    X, y = make_regression(n_samples=100, chunks=50, random_state=0)
+
+    real = sklearn.linear_model.LinearRegression()
+    fake = dask_ml.iid.linear_model.LinearRegression()
+
+    real.fit(X[:50], y[:50])
+    fake.fit(X, y)
+
+    assert_estimator_equal(fake, real, tol=1e-5)
+    assert isinstance(fake.predict(X), type(X))
+
+    X, y = make_regression(n_samples=100, chunks=50, random_state=0)
+    X = dd.from_dask_array(X)
+    y = dd.from_dask_array(y)
+
+    real = sklearn.linear_model.LinearRegression()
+    fake = dask_ml.iid.linear_model.LinearRegression()
+
+    real.fit(X.get_partition(0), y.get_partition(0))
+    fake.fit(X, y)
+
+    assert_estimator_equal(fake, real, tol=1e-5)
+    assert isinstance(fake.predict(X), da.Array)
+
+
+def test_all(model):
+    if model.__name__ in skips:
+        pytest.skip(model.__name__)
+
+    kwargs = {}
+    if 'random_state' in set(inspect.getfullargspec(model).args):
+        kwargs['random_state'] = 0
+
+    if isinstance(model, sklearn.base.RegressorMixin):
+        X, y = make_regression(n_samples=100, chunks=50, random_state=0)
+    else:
+        X, y = make_classification(n_samples=100, chunks=50, random_state=0)
+
+    real = model(**kwargs)
+    fake = getattr(getattr(dask_ml.iid, model.__module__.split('.')[1]),
+                   model.__name__)(**kwargs)
+    with pytest.warns(None):
+        # We don't care about any deprecation warnings
+        try:
+            real.fit(X[:50], y[:50])
+        except Exception as e:
+            pytest.skip(e.args[0])
+
+        fake.fit(X, y)
+
+        # Bug in sklearn for SVR.n_support?
+        assert_estimator_equal(fake, real, atol=1e-5, exclude=['n_support_'])
+
+    if hasattr(real, 'predict'):
+        assert isinstance(fake.predict(X), type(X))
+    else:
+        has_it = hasattr(fake, 'predict')
+        if has_it:
+            # Some attrs depend on specific values
+            with pytest.raises(AttributeError):
+                fake.predict(X)
+
+    if hasattr(real, 'predict_proba'):
+        assert isinstance(fake.predict_proba(X), type(X))
+    else:
+        has_it = hasattr(fake, 'predict_proba')
+
+        if has_it:
+            # Some attrs depend on specific values
+            with pytest.raises(AttributeError):
+                fake.predict_proba(X)


### PR DESCRIPTION
Adds a new subpackage `dask_ml.iid` that wraps most estimators from scikit-learn so that

1. Training is done just on the first block / partition of a dask array or dataframe.
2. Transform and predict work correctly on dask arrays or dataframes

This covers the common case observed by @GaelVaroquaux that we're often OK with training on a sample.

TODO:

- Alternative name? I like `dask_ml.iid`, since it drives home the point that these wrappers aren't appropriate for all types of data. We'll need to do some education for users who aren't familiar with the term though.
- Alternative implementation? We could provide a function that rewrites a class after it's been created (similar to what `sklearn-xarray` does.) How does that affect pickling?
- Docs? Do we want to include every estimator in our API docs? What value does that bring, over saying 'just look at scikit-learn'?
- Other methods to implement? `score` probably, anything else?

Closes #126 