### PR TITLE
MAINT: check if matrix is an ndarray in predict

### DIFF
--- a/dask_ml/base.py
+++ b/dask_ml/base.py
@@ -69,6 +69,8 @@ class _BigPartialFitMixin(object):
         predict = super(_BigPartialFitMixin, self).predict
         if dtype is None:
             dtype = self._get_predict_dtype(X)
+        if isinstance(X, np.ndarray):
+            return predict(X)
         return X.map_blocks(predict, dtype=dtype, drop_axis=1)
 
     def _get_predict_dtype(self, X):

--- a/tests/linear_model/test_stochastic_gradient.py
+++ b/tests/linear_model/test_stochastic_gradient.py
@@ -17,6 +17,19 @@ class TestStochasticGradientClassifier(object):
         b.partial_fit(X, y, classes=[0, 1])
         assert_estimator_equal(a, b, exclude='loss_function_')
 
+    def test_numpy_arrays(self, single_chunk_classification):
+        # fit with dask arrays, test with numpy arrays
+        X, y = single_chunk_classification
+
+        a = lm.PartialSGDClassifier(classes=[0, 1], random_state=0,
+                                    max_iter=1000, tol=1e-3)
+
+        a.fit(X, y)
+        X = X.compute()
+        y = y.compute()
+        y_hat = a.predict(X)
+        a.score(X, y)
+
 
 class TestStochasticGradientRegressor(object):
 
@@ -29,3 +42,14 @@ class TestStochasticGradientRegressor(object):
         a.fit(X, y)
         b.partial_fit(X, y)
         assert_estimator_equal(a, b)
+
+    def test_numpy_arrays(self, single_chunk_regression):
+        X, y = single_chunk_regression
+        a = lm.PartialSGDRegressor(random_state=0,
+                                   max_iter=1000, tol=1e-3)
+
+        a.fit(X, y)
+        X = X.compute()
+        y = y.compute()
+        y_hat = a.predict(X)
+        a.score(X, y)


### PR DESCRIPTION
This makes `model.score` more robust to types (and resolves an issue I had).

