### PR TITLE
Blockwise Metaestimator

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -29,6 +29,7 @@ _partial_deprecation = (
     "instead."
 )
 
+
 @six.add_metaclass(_WritableDoc)
 class _BigPartialFitMixin(object):
     """ Wraps a partial_fit enabled estimator for use with Dask arrays """

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -211,6 +211,9 @@ def _copy_partial_doc(cls):
 
     insert = """
 
+    .. deprecated:: 0.6.0
+       Use the :class:`dask_ml.wrappers.Incremental` meta-estimator instead.
+
     This class wraps scikit-learn's {classname}. When a dask-array is passed
     to our ``fit`` method, the array is passed block-wise to the scikit-learn
     class' ``partial_fit`` method. This will allow you to fit the estimator

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -244,7 +244,7 @@ class Incremental(ParallelPostFit):
     Parameters
     ----------
     estimator : Estimator
-        Any object supporting the scikit-learn `parital_fit` API.
+        Any object supporting the scikit-learn ``parital_fit`` API.
     **kwargs
         Additional keyword arguments passed through the the underlying
         estimator's `partial_fit` method.
@@ -274,6 +274,21 @@ class Incremental(ParallelPostFit):
         for k, v in attrs.items():
             setattr(self, k, v)
         return self
+
+    def partial_fit(self, X, y=None):
+        """Fit the underlying estimator.
+
+        This is identical to ``fit``.
+
+        Parameters
+        ----------
+        X, y : array-like
+
+        Returns
+        -------
+        self : object
+        """
+        return self.fit(X, y)
 
 
 def _first_block(dask_object):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,11 @@ API Breaking Changes
 
 - Removed the `get` keyword from the incremental learner ``fit`` methods (:pr:`187`)
 
+Enhancements
+------------
+
+- Added a new meta-estimator :class:`dask_ml.wrappers.Blockwise` for wrapping any estimator with a `partial_fit` method (). See :ref:`incremental.blockwise-metaestimator` for more.
+
 Version 0.5.0
 ~~~~~~~~~~~~~
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,12 +7,13 @@ Version 0.6.0
 API Breaking Changes
 --------------------
 
-- Removed the `get` keyword from the incremental learner ``fit`` methods (:pr:`187`)
-
+- Removed the `get` keyword from the incremental learner ``fit`` methods. (:pr:`187`)
+- Deprecated the various ``Partial*`` estimators in favor of the :class:`dask_ml.wrappers.Incremental` meta-estimator (:pr:`190`)
+  
 Enhancements
 ------------
 
-- Added a new meta-estimator :class:`dask_ml.wrappers.Incremental` for wrapping any estimator with a `partial_fit` method (). See :ref:`incremental.blockwise-metaestimator` for more.
+- Added a new meta-estimator :class:`dask_ml.wrappers.Incremental` for wrapping any estimator with a `partial_fit` method. See :ref:`incremental.blockwise-metaestimator` for more. (:pr:`190`)
 
 Version 0.5.0
 ~~~~~~~~~~~~~

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,7 +12,7 @@ API Breaking Changes
 Enhancements
 ------------
 
-- Added a new meta-estimator :class:`dask_ml.wrappers.Blockwise` for wrapping any estimator with a `partial_fit` method (). See :ref:`incremental.blockwise-metaestimator` for more.
+- Added a new meta-estimator :class:`dask_ml.wrappers.Incremental` for wrapping any estimator with a `partial_fit` method (). See :ref:`incremental.blockwise-metaestimator` for more.
 
 Version 0.5.0
 ~~~~~~~~~~~~~

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -16,7 +16,7 @@ The incremental learning tools in Dask-ML provide a bridge between Dask and
 Scikit-Learn estimators supporting the ``partial_fit`` API. Each individual
 chunk in a Dask Array can be passed to the estimator's ``partial_fit`` method.
 
-Dask-ML provides two ways to achieve this: :ref:`incremental.blockwise-metaestimator`, for wrapping any estimator with a `partial_fit` method, and :ref:`incremental.pre-wrapped` for estimators that have already been wrapped in the meta-estimator.
+Dask-ML provides two ways to achieve this: :ref:`incremental.blockwise-metaestimator`, for wrapping any estimator with a `partial_fit` method, and some pre-daskified :ref:`incremental.dask-friendly` incremental.
 
 .. _incremental.blockwise-metaestimator:
 
@@ -71,17 +71,25 @@ care of passing each block to the underlying estimator for you.
 
 .. _incremental.pre-wrapped:
 
-Pre-Wrapped Incremental Learners
-================================
+Daskified Incremental Learners
+===============================
 
-Dask-ML provides pre-wrapped versions of some common estimators. They'll be
-found in the same namespace as their scikit-learn counterparts they wrap.
+Dask-ML provides a few estimators that effectively do the wrapping for you.
+The main differences from :class:`dask_ml.wrappers.Blockwise` is that
+
+1. They're found in the corresponding Dask-ML namespace (e.g.
+   :class:`dask_ml.linear_model.SGDClassifier`).
+2. They're regular estimators (not meta-estimators).
+
+Calling them is just like calling the scikit-learn estimator, except that you
+use Dask Arrays instead of NumPy arrays, and you pass all the ``fit_kwargs`` to
+the estimator itself.
 
 .. ipython:: python
 
-   from dask_ml.linear_model import PartialSGDRegressor
+   from dask_ml.linear_model import PartialSGDClassifier
    from dask_ml.datasets import make_classification
-   est = PartialSGDRegressor()
+   est = PartialSGDClassifier(classes=[0, 1])
    est.fit(X, y)
 
 See :ref:`api.incremental` for a full list of the wrapped estimators.

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -20,15 +20,15 @@ Dask-ML provides two ways to achieve this: :ref:`incremental.blockwise-metaestim
 
 .. _incremental.blockwise-metaestimator:
 
-Blockwise Metaestimator
------------------------
+Incremental Metaestimator
+-------------------------
 
 .. currentmodule::  dask_ml
 
 .. autosummary::
-   wrappers.Blockwise
+   wrappers.Incremental
 
-:class:`dask_ml.wrappers.Blockwise` is a meta-estimator (an estimator that
+:class:`dask_ml.wrappers.Incremental` is a meta-estimator (an estimator that
 takes another estimator) that bridges scikit-learn estimators expecting
 NumPy arrays, and users with large Dask Arrays.
 
@@ -43,14 +43,14 @@ between machines.
 .. ipython:: python
 
    from dask_ml.datasets import make_classification
-   from dask_ml.wrappers import Blockwise
+   from dask_ml.wrappers import Incremental
    from sklearn.linear_model import SGDClassifier
 
    X, y = make_classification(chunks=25)
    X
 
    estimator = SGDClassifier(random_state=10)
-   clf = Blockwise(estimator, classes=[0, 1])
+   clf = Incremental(estimator, classes=[0, 1])
    clf.fit(X, y)
 
 In this example, we make a (small) random Dask Array. It has 100 samples,
@@ -61,37 +61,12 @@ You instantite the underlying estimator as usual. It really is just a
 scikit-learn compatible estimator, and will be trained normally via its
 ``partial_fit``.
 
-When wrapping the estimator in :class:`Blockwise`, you need to pass any
+When wrapping the estimator in :class:`Incremental`, you need to pass any
 keyword arguments that are expected by the underlying ``partial_fit`` method.
 With :class:`sklearn.linear_model.SGDClassifier`, we're required to provide
 the list of unique ``classes`` in ``y``.
 
 Notice that we call the regular ``.fit`` method for training. Dask-ML takes
 care of passing each block to the underlying estimator for you.
-
-.. _incremental.pre-wrapped:
-
-Daskified Incremental Learners
-===============================
-
-Dask-ML provides a few estimators that effectively do the wrapping for you.
-The main differences from :class:`dask_ml.wrappers.Blockwise` is that
-
-1. They're found in the corresponding Dask-ML namespace (e.g.
-   :class:`dask_ml.linear_model.SGDClassifier`).
-2. They're regular estimators (not meta-estimators).
-
-Calling them is just like calling the scikit-learn estimator, except that you
-use Dask Arrays instead of NumPy arrays, and you pass all the ``fit_kwargs`` to
-the estimator itself.
-
-.. ipython:: python
-
-   from dask_ml.linear_model import PartialSGDClassifier
-   from dask_ml.datasets import make_classification
-   est = PartialSGDClassifier(classes=[0, 1])
-   est.fit(X, y)
-
-See :ref:`api.incremental` for a full list of the wrapped estimators.
 
 .. _incremental learning: http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -3,25 +3,24 @@
 Incremental Learning
 ====================
 
-Some estimators can be trained incrementally -- without seeing the entire dataset at once.
-Scikit-Learn provdes the ``partial_fit`` API to let you stream batches of data
-to an estimator that can be fit in batches.
+Some estimators can be trained incrementally -- without seeing the entire
+dataset at once. Scikit-Learn provdes the ``partial_fit`` API to stream batches
+of data to an estimator that can be fit in batches.
 
 Normally, if you pass a Dask Array to an estimator expecting a NumPy array,
 the Dask Array will be converted to a single, large NumPy array. On a single
 machine, you'll likely run out of RAM and crash the program. On a distributed
 cluster, all the workers will send their data to a single machine and crash it.
 
-The incremental learning tools in Dask-ML provide a bridge between Dask and
-Scikit-Learn estimators supporting the ``partial_fit`` API. Each individual
-chunk in a Dask Array can be passed to the estimator's ``partial_fit`` method.
-
-Dask-ML provides two ways to achieve this: :ref:`incremental.blockwise-metaestimator`, for wrapping any estimator with a `partial_fit` method, and some pre-daskified :ref:`incremental.dask-friendly` incremental.
+:class:`dask_ml.wrappers.Incremental` provides a bridge between Dask and
+Scikit-Learn estimators supporting the ``partial_fit`` API. You wrap the
+underlying estimator in ``Incremental``. Dask-ML will sequentially pass each
+block of a Dask Array to the underlying estimator's ``partial_fit`` method.
 
 .. _incremental.blockwise-metaestimator:
 
-Incremental Metaestimator
--------------------------
+Incremental Meta-estimator
+--------------------------
 
 .. currentmodule::  dask_ml
 
@@ -35,7 +34,7 @@ NumPy arrays, and users with large Dask Arrays.
 Each *block* of a Dask Array is fed to the underlying estiamtor's
 ``partial_fit`` method. The training is entirely sequential, so you won't
 notice massive training time speedups from parallelism. In a distributed
-environment, you should notice some speeds from avoiding extra IO, and the
+environment, you should notice some speedup from avoiding extra IO, and the
 fact that models are typically much smaller than data, and so faster to move
 between machines.
 

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -73,12 +73,7 @@ compatible estimators with Dask arrays.
    :template: class.rst
 
    wrappers.ParallelPostFit
-   wrappers.Blockwise
-
-.. autosummary::
-   :toctree: generated/
-
-   wrappers.make_blockwise
+   wrappers.Incremental
 
 
 .. _api.incremental-learning:

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -75,34 +75,6 @@ compatible estimators with Dask arrays.
    wrappers.ParallelPostFit
    wrappers.Incremental
 
-
-.. _api.incremental-learning:
-
-Incremental Learning
-====================
-
-.. currentmodule:: dask_ml
-
-Some scikit-learn estimators support out-of-core training through the
-``partial_fit`` method. The following estimators wrap those scikit-learn
-estimators, allowing them to be used in Pipelines and on Dask arrays and
-dataframes. Training will still be serial, so these will not benefit from
-a parallel or distributed training any more than the underlying estimator.
-
-.. autosummary::
-   :toctree: generated/
-   :template: class.rst
-
-   cluster.PartialMiniBatchKMeans
-   linear_model.PartialPassiveAggressiveClassifier
-   linear_model.PartialPassiveAggressiveRegressor
-   linear_model.PartialPerceptron
-   linear_model.PartialSGDClassifier
-   linear_model.PartialSGDRegressor
-   naive_bayes.PartialBernoulliNB
-   naive_bayes.PartialMultinomialNB
-
-
 :mod:`dask_ml.cluster`: Clustering
 ==================================
 

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -63,7 +63,8 @@ Dask-ML provides drop-in replacements for grid and randomized search.
 Meta-estimators for scikit-learn
 ================================
 
-dask-ml provides some meta-estimators parallelize certain components.
+dask-ml provides some meta-estimators that help use regular scikit-learn
+compatible estimators with Dask arrays.
 
 .. currentmodule:: dask_ml
 
@@ -72,7 +73,15 @@ dask-ml provides some meta-estimators parallelize certain components.
    :template: class.rst
 
    wrappers.ParallelPostFit
+   wrappers.Blockwise
 
+.. autosummary::
+   :toctree: generated/
+
+   wrappers.make_blockwise
+
+
+.. _api.incremental-learning:
 
 Incremental Learning
 ====================

--- a/tests/linear_model/test_neural_network.py
+++ b/tests/linear_model/test_neural_network.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sklearn import neural_network as nn_
 from dask_ml import neural_network as nn
 

--- a/tests/linear_model/test_neural_network.py
+++ b/tests/linear_model/test_neural_network.py
@@ -6,7 +6,7 @@ from dask_ml import neural_network as nn
 from dask_ml.utils import assert_estimator_equal
 
 
-@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestMLPClassifier(object):
 
     def test_basic(self, single_chunk_classification):
@@ -18,7 +18,7 @@ class TestMLPClassifier(object):
         assert_estimator_equal(a, b)
 
 
-@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestMLPRegressor(object):
 
     def test_basic(self, single_chunk_classification):

--- a/tests/linear_model/test_neural_network.py
+++ b/tests/linear_model/test_neural_network.py
@@ -4,6 +4,7 @@ from dask_ml import neural_network as nn
 from dask_ml.utils import assert_estimator_equal
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestMLPClassifier(object):
 
     def test_basic(self, single_chunk_classification):
@@ -15,6 +16,7 @@ class TestMLPClassifier(object):
         assert_estimator_equal(a, b)
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestMLPRegressor(object):
 
     def test_basic(self, single_chunk_classification):

--- a/tests/linear_model/test_passive_aggressive.py
+++ b/tests/linear_model/test_passive_aggressive.py
@@ -1,9 +1,12 @@
+import pytest
+
 from sklearn import linear_model as lm_
 from dask_ml import linear_model as lm
 
 from dask_ml.utils import assert_estimator_equal
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestPassiveAggressiveClassifier(object):
 
     def test_basic(self, single_chunk_classification):
@@ -18,6 +21,7 @@ class TestPassiveAggressiveClassifier(object):
         assert_estimator_equal(a, b, exclude=['loss_function_'])
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestPassiveAggressiveRegressor(object):
 
     def test_basic(self, single_chunk_regression):

--- a/tests/linear_model/test_perceptron.py
+++ b/tests/linear_model/test_perceptron.py
@@ -1,9 +1,12 @@
+import pytest
+
 from sklearn.linear_model import Perceptron
 from dask_ml.linear_model import PartialPerceptron
 
 from dask_ml.utils import assert_estimator_equal
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestPerceptron(object):
 
     def test_basic(self, single_chunk_classification):

--- a/tests/linear_model/test_stochastic_gradient.py
+++ b/tests/linear_model/test_stochastic_gradient.py
@@ -1,3 +1,4 @@
+import pytest
 from dask.delayed import Delayed
 from sklearn import linear_model as lm_
 from dask_ml import linear_model as lm
@@ -5,6 +6,7 @@ from dask_ml import linear_model as lm
 from dask_ml.utils import assert_estimator_equal
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestStochasticGradientClassifier(object):
 
     def test_basic(self, single_chunk_classification):
@@ -32,6 +34,7 @@ class TestStochasticGradientClassifier(object):
         a.score(X, y)
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestStochasticGradientRegressor(object):
 
     def test_basic(self, single_chunk_regression):
@@ -56,6 +59,7 @@ class TestStochasticGradientRegressor(object):
         a.score(X, y)
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 def test_lazy(xy_classification):
     X, y = xy_classification
     sgd = lm.PartialSGDClassifier(classes=[0, 1])
@@ -63,3 +67,14 @@ def test_lazy(xy_classification):
     assert isinstance(r, Delayed)
     result = r.compute()
     assert isinstance(result, lm_.SGDClassifier)
+
+
+def test_deprecated():
+    expected = (
+        r"'PartialSGDClassifier' is deprecated. Use "
+        r"'dask_ml.wrappers.Incremental.*SGDClassifier.*"
+        r"instead."
+    )
+
+    with pytest.warns(FutureWarning, match=expected):
+        lm.PartialSGDClassifier(classes=[0, 1])

--- a/tests/linear_model/test_stochastic_gradient.py
+++ b/tests/linear_model/test_stochastic_gradient.py
@@ -1,4 +1,5 @@
 import pytest
+import six
 from dask.delayed import Delayed
 from sklearn import linear_model as lm_
 from dask_ml import linear_model as lm
@@ -69,6 +70,7 @@ def test_lazy(xy_classification):
     assert isinstance(result, lm_.SGDClassifier)
 
 
+@pytest.mark.skipif(six.PY2, reason="Python 2 failure.")
 def test_deprecated():
     expected = (
         r"'PartialSGDClassifier' is deprecated. Use "

--- a/tests/test_blockwise.py
+++ b/tests/test_blockwise.py
@@ -1,0 +1,40 @@
+import dask.array as da
+from dask.array.utils import assert_eq
+import numpy as np
+import pytest
+from sklearn.base import clone
+from sklearn.linear_model import SGDClassifier
+
+from dask_ml.wrappers import Blockwise, make_blockwise
+from dask_ml.utils import assert_estimator_equal
+
+
+@pytest.mark.parametrize('maker', [Blockwise, make_blockwise])
+def test_blockwise_basic(xy_classification, maker):
+    X, y = xy_classification
+    est1 = SGDClassifier(random_state=0)
+    est2 = clone(est1)
+
+    clf = maker(est1, classes=[0, 1])
+    result = clf.fit(X, y)
+    for slice_ in da.core.slices_from_chunks(X.chunks):
+        est2.partial_fit(X[slice_], y[slice_[0]], classes=[0, 1])
+
+    assert result is clf
+
+    assert isinstance(result.estimator.coef_, np.ndarray)
+    np.testing.assert_array_almost_equal(result.estimator.coef_, est2.coef_)
+
+    assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
+
+    #  Predict
+    result = clf.predict(X)
+    expected = est2.predict(X)
+    assert isinstance(result, da.Array)
+    assert_eq(result, expected)
+
+    # score
+    result = clf.score(X, y)
+    expected = est2.score(X, y)
+    # assert isinstance(result, da.Array)
+    assert_eq(result, expected)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -36,3 +36,7 @@ def test_incremental_basic(xy_classification):
     expected = est2.score(X, y)
     # assert isinstance(result, da.Array)
     assert_eq(result, expected)
+
+    clf = Incremental(SGDClassifier(random_state=0), classes=[0, 1])
+    clf.partial_fit(X, y)
+    assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,21 +1,19 @@
 import dask.array as da
 from dask.array.utils import assert_eq
 import numpy as np
-import pytest
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
-from dask_ml.wrappers import Blockwise, make_blockwise
+from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
 
 
-@pytest.mark.parametrize('maker', [Blockwise, make_blockwise])
-def test_blockwise_basic(xy_classification, maker):
+def test_incremental_basic(xy_classification):
     X, y = xy_classification
     est1 = SGDClassifier(random_state=0)
     est2 = clone(est1)
 
-    clf = maker(est1, classes=[0, 1])
+    clf = Incremental(est1, classes=[0, 1])
     result = clf.fit(X, y)
     for slice_ in da.core.slices_from_chunks(X.chunks):
         est2.partial_fit(X[slice_], y[slice_[0]], classes=[0, 1])

--- a/tests/test_minibatch.py
+++ b/tests/test_minibatch.py
@@ -1,9 +1,12 @@
+import pytest
+
 from sklearn import cluster as cluster_
 from dask_ml import cluster
 
 from dask_ml.utils import assert_estimator_equal
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestMiniBatchKMeans(object):
 
     def test_basic(self, single_chunk_blobs):

--- a/tests/test_naive_bayes.py
+++ b/tests/test_naive_bayes.py
@@ -1,3 +1,4 @@
+import pytest
 from dask.array.utils import assert_eq
 from dask_ml.datasets import make_classification
 from dask_ml import naive_bayes as nb
@@ -24,6 +25,7 @@ def test_smoke():
     assert_eq(a.predict_log_proba(X).compute(), b.predict_log_proba(X_))
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestPartialMultinomialNB(object):
     def test_basic(self, single_chunk_count_classification):
         X, y = single_chunk_count_classification
@@ -34,6 +36,7 @@ class TestPartialMultinomialNB(object):
         assert_eq(a.coef_, b.coef_)
 
 
+@pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 class TestPartialBernoulliNB(object):
     def test_basic(self, single_chunk_binary_classification):
         X, y = single_chunk_binary_classification


### PR DESCRIPTION
Adds a meta-estimator for wrapping estimators that implement `partial_fit`.

```python
In [1]: from dask_ml.wrappers import Blockwise
   ...: from dask_ml.datasets import make_classification
   ...: import sklearn.linear_model
   ...:
   ...:

In [2]: X, y = make_classification(chunks=25)

In [3]: est = sklearn.linear_model.SGDClassifier()

In [4]: clf = Blockwise(est, classes=[0, 1])

In [5]: clf.fit(X, y)
Out[5]:
Blockwise(estimator=SGDClassifier(alpha=0.0001, average=False, class_weight=None, epsilon=0.1,
       eta0=0.0, fit_intercept=True, l1_ratio=0.15,
       learning_rate='optimal', loss='hinge', max_iter=None, n_iter=None,
       n_jobs=1, penalty='l2', power_t=0.5, random_state=None,
       shuffle=True, tol=None, verbose=0, warm_start=False))
```

A few notes:

1. The name: I went with `Blockwise`. We could also do `Streamable`, but I worry people will avoid using it if they think "I don't have streaming data, so this isn't for me.". Any thoughts on the name?
2. Currently, there's a lot of overlap with the various `Partial*` estimators scattered throughout dask-ml in terms of code and use. I can / will reduce the code duplication before merging. API-wise, there are benefits to the both. The meta-estimator is nice since it can wrap *any* sklearn-compatible estimator that implements `partial_fit` (e.g. from modl). But the "pre-wrapped" versions are maybe nicer for discovery?
3. I went with `**kwargs` for the signature instead of a `fit_params` dict. I could see either working but `**kwargs` felt a bit more natural.

cc @jakirkham @ogrisel 

Closes #188 