### PR TITLE
ENH: Make Incremental work in grid search

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -11,6 +11,8 @@ from toolz import partial
 import dask
 from dask.delayed import Delayed
 
+from ._utils import copy_learned_attributes
+
 
 class _WritableDoc(ABCMeta):
     """In py27, classes inheriting from `object` do not have
@@ -77,12 +79,8 @@ class _BigPartialFitMixin(object):
         fit_kwargs = {k: getattr(self, k) for k in self._fit_kwargs}
         result = fit(self, X, y, compute=compute, **fit_kwargs)
 
-        # Copy the learned attributes over to self
-        # It should go without saying that this is *not* threadsafe
         if compute:
-            attrs = {k: v for k, v in vars(result).items() if k.endswith('_')}
-            for k, v in attrs.items():
-                setattr(self, k, v)
+            copy_learned_attributes(result, self)
             return self
         return result
 

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 import os
 import warnings
 from abc import ABCMeta
+from timeit import default_timer as tic
 
 import numpy as np
 import six
@@ -12,6 +14,9 @@ import dask
 from dask.delayed import Delayed
 
 from ._utils import copy_learned_attributes
+
+
+logger = logging.getLogger(__name__)
 
 
 class _WritableDoc(ABCMeta):
@@ -99,7 +104,12 @@ class _BigPartialFitMixin(object):
 
 def _partial_fit(model, x, y, kwargs=None):
     kwargs = kwargs or dict()
+    start = tic()
+    logger.info("Starting partial-fit %s", dask.base.tokenize(model, x, y))
     model.partial_fit(x, y, **kwargs)
+    stop = tic()
+    logger.info("Finished partial-fit %s [%0.2f]",
+                dask.base.tokenize(model, x, y), stop - start)
     return model
 
 

--- a/dask_ml/_utils.py
+++ b/dask_ml/_utils.py
@@ -1,0 +1,5 @@
+def copy_learned_attributes(from_estimator, to_estimator):
+    attrs = {k: v for k, v in vars(from_estimator).items() if k.endswith('_')}
+
+    for k, v in attrs.items():
+        setattr(to_estimator, k, v)

--- a/dask_ml/metrics/__init__.py
+++ b/dask_ml/metrics/__init__.py
@@ -11,3 +11,8 @@ from .regression import (  # noqa
 from .classification import (  # noqa
     accuracy_score,
 )
+
+from .scorer import (  # noqa
+    get_scorer,
+    SCORERS,
+)

--- a/dask_ml/metrics/classification.py
+++ b/dask_ml/metrics/classification.py
@@ -1,4 +1,5 @@
-def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
+def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None,
+                   compute=True):
     """Accuracy classification score.
 
     In multilabel classification, this function computes subset accuracy:
@@ -68,6 +69,10 @@ def accuracy_score(y_true, y_pred, normalize=True, sample_weight=None):
         score = y_true == y_pred
 
     if normalize:
-        return score.mean()
+        score = score.mean()
     else:
-        return score.sum()
+        score = score.sum()
+
+    if compute:
+        score = score.compute()
+    return score

--- a/dask_ml/metrics/regression.py
+++ b/dask_ml/metrics/regression.py
@@ -26,7 +26,8 @@ def _check_reg_targets(y_true, y_pred, multioutput):
 @doc_wraps(sklearn.metrics.mean_squared_error)
 def mean_squared_error(y_true, y_pred,
                        sample_weight=None,
-                       multioutput='uniform_average'):
+                       multioutput='uniform_average',
+                       compute=True):
     _check_sample_weight(sample_weight)
     output_errors = ((y_pred - y_true) ** 2).mean(axis=0)
 
@@ -38,13 +39,17 @@ def mean_squared_error(y_true, y_pred,
             multioutput = None
     else:
         raise ValueError("Weighted 'multioutput' not supported.")
-    return output_errors.mean()
+    result = output_errors.mean()
+    if compute:
+        result = result.compute()
+    return result
 
 
 @doc_wraps(sklearn.metrics.mean_squared_error)
 def mean_absolute_error(y_true, y_pred,
                         sample_weight=None,
-                        multioutput='uniform_average'):
+                        multioutput='uniform_average',
+                        compute=True):
     _check_sample_weight(sample_weight)
     output_errors = abs(y_pred - y_true).mean(axis=0)
 
@@ -56,12 +61,16 @@ def mean_absolute_error(y_true, y_pred,
             multioutput = None
     else:
         raise ValueError("Weighted 'multioutput' not supported.")
-    return output_errors.mean()
+    result = output_errors.mean()
+    if compute:
+        result = result.compute()
+    return result
 
 
 @doc_wraps(sklearn.metrics.r2_score)
 def r2_score(y_true, y_pred, sample_weight=None,
-             multioutput="uniform_average"):
+             multioutput="uniform_average",
+             compute=True):
     _check_sample_weight(sample_weight)
     _, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput
@@ -79,4 +88,7 @@ def r2_score(y_true, y_pred, sample_weight=None,
     output_scores[valid_score] = 1 - (numerator[valid_score] /
                                       denominator[valid_score])
     output_scores[nonzero_numerator & ~nonzero_denominator] = 0.
-    return output_scores.mean(axis=0)
+    result = output_scores.mean(axis=0)
+    if compute:
+        result = result.compute()
+    return result

--- a/dask_ml/metrics/scorer.py
+++ b/dask_ml/metrics/scorer.py
@@ -1,0 +1,49 @@
+import six
+from sklearn.metrics import make_scorer
+
+from . import (
+    accuracy_score,
+    mean_squared_error,
+    r2_score,
+)
+
+# Scorers
+accuracy_scorer = make_scorer(accuracy_score)
+neg_mean_squared_error_scorer = make_scorer(mean_squared_error,
+                                            greater_is_better=False)
+r2_scorer = make_scorer(r2_score)
+
+
+SCORERS = dict(
+    accuracy=accuracy_scorer,
+    neg_mean_squared_error=neg_mean_squared_error_scorer,
+    r2=r2_scorer,
+)
+
+
+def get_scorer(scoring, compute=True):
+    """Get a scorer from string
+
+    Parameters
+    ----------
+    scoring : str | callable
+        scoring method as string. If callable it is returned as is.
+
+    Returns
+    -------
+    scorer : callable
+        The scorer.
+    """
+    # This is the same as sklearns, only we use our SCORERS dict,
+    # and don't have back-compat code
+    if isinstance(scoring, six.string_types):
+        try:
+            scorer = SCORERS[scoring]
+        except KeyError:
+            raise ValueError('{} is not a valid scoring value. '
+                             'Valid options are {}'.format(scoring,
+                                                           sorted(SCORERS)))
+    else:
+        scorer = scoring
+
+    return scorer

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -262,6 +262,11 @@ class Incremental(ParallelPostFit):
     >>> clf = Incremental(est)
     >>> clf.fit(X, y, classes=[0, 1])
     """
+    _estimator_clash_message = (
+        "The 'estimator' parameter is used by both 'Incremental' and the"
+        "underlying estimator, which will produce incorrect results."
+    )
+
     def __init__(self, estimator, **kwargs):
         estimator.set_params(**kwargs)
         self.estimator = estimator
@@ -286,10 +291,14 @@ class Incremental(ParallelPostFit):
 
     def get_params(self, deep=True):
         out = self.estimator.get_params(deep=deep)
+        if 'estimator' in out:
+            raise ValueError(self._estimator_clash_message)
         out['estimator'] = self.estimator
         return out
 
     def set_params(self, **kwargs):
+        if 'estimator' in kwargs:
+            raise ValueError(self._estimator_clash_message)
         self.estimator.set_params(**kwargs)
         return self
 

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -305,11 +305,14 @@ class Incremental(ParallelPostFit):
         if 'estimator' in out:
             raise ValueError(self._estimator_clash_message)
         out['estimator'] = self.estimator
+        out['scoring'] = self.scoring
         return out
 
     def set_params(self, **kwargs):
         if 'estimator' in kwargs:
             raise ValueError(self._estimator_clash_message)
+        if 'scoring' in kwargs:
+            self.scoring = kwargs['scoring']
         self.estimator.set_params(**kwargs)
         return self
 

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -49,8 +49,8 @@ between machines.
    X
 
    estimator = SGDClassifier(random_state=10)
-   clf = Incremental(estimator, classes=[0, 1])
-   clf.fit(X, y)
+   clf = Incremental(estimator)
+   clf.fit(X, y, classes=[0, 1])
 
 In this example, we make a (small) random Dask Array. It has 100 samples,
 broken in the 4 blocks of 25 samples each. The chunking is only along the
@@ -60,12 +60,13 @@ You instantite the underlying estimator as usual. It really is just a
 scikit-learn compatible estimator, and will be trained normally via its
 ``partial_fit``.
 
-When wrapping the estimator in :class:`Incremental`, you need to pass any
-keyword arguments that are expected by the underlying ``partial_fit`` method.
-With :class:`sklearn.linear_model.SGDClassifier`, we're required to provide
-the list of unique ``classes`` in ``y``.
+Notice that we call the regular ``.fit`` method, not ``partial_fit`` for
+training. Dask-ML takes care of passing each block to the underlying estimator
+for you.
 
-Notice that we call the regular ``.fit`` method for training. Dask-ML takes
-care of passing each block to the underlying estimator for you.
+Just like :meth:`sklearn.linear_model.SGDClassifier.partial_fit`, we need to
+pass the ``classes`` argument to ``fit``. In general, any argument that is
+requierd for the underlying estimators ``parital_fit`` becomes required for
+the wrapped ``fit``.
 
 .. _incremental learning: http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import contextlib
+
+from distributed.utils_test import cluster
 import pytest
 import numpy as np
 
@@ -123,3 +126,16 @@ def single_chunk_blobs():
     """
     X, y = make_blobs(chunks=100, random_state=0)
     return X, y
+
+
+@contextlib.contextmanager
+def not_cluster(nworkers=2, **kwargs):
+    yield (None, [None] * nworkers)
+
+
+@pytest.fixture(scope='module', params=['threads', 'distributed'])
+def scheduler(request):
+    if request.param == 'distributed':
+        yield cluster
+    else:
+        yield not_cluster

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -1,6 +1,7 @@
-import pytest
+import numbers
 
 import dask.array as da
+import pytest
 import sklearn.metrics
 
 import dask_ml.metrics
@@ -25,7 +26,8 @@ def normalize(request):
 
 
 @pytest.mark.parametrize('size', [(100,), (100, 2)])
-def test_ok(size, metric_pairs, normalize):
+@pytest.mark.parametrize('compute', [True, False])
+def test_ok(size, metric_pairs, normalize, compute):
     m1, m2 = metric_pairs
 
     if len(size) == 1:
@@ -35,6 +37,10 @@ def test_ok(size, metric_pairs, normalize):
     a = da.random.random_integers(0, hi, size=size, chunks=25)
     b = da.random.random_integers(0, hi, size=size, chunks=25)
 
-    result = m1(a, b, normalize=normalize)
+    result = m1(a, b, normalize=normalize, compute=compute)
+    if compute:
+        assert isinstance(result, numbers.Real)
+    else:
+        assert isinstance(result, da.Array)
     expected = m2(a, b, normalize=normalize)
     assert abs(result - expected) < 1e-5

--- a/tests/metrics/test_regression.py
+++ b/tests/metrics/test_regression.py
@@ -1,6 +1,7 @@
-import pytest
+import numbers
 
 import dask.array as da
+import pytest
 import sklearn.metrics
 
 import dask_ml.metrics
@@ -22,12 +23,17 @@ def metric_pairs(request):
     )
 
 
-def test_ok(metric_pairs):
+@pytest.mark.parametrize('compute', [True, False])
+def test_ok(metric_pairs, compute):
     m1, m2 = metric_pairs
 
     a = da.random.uniform(size=(100,), chunks=(25,))
     b = da.random.uniform(size=(100,), chunks=(25,))
 
-    result = m1(a, b)
+    result = m1(a, b, compute=compute)
+    if compute:
+        assert isinstance(result, numbers.Real)
+    else:
+        assert isinstance(result, da.Array)
     expected = m2(a, b)
     assert abs(result - expected) < 1e-5

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -50,7 +50,7 @@ def test_make_regression():
     dask_ml.datasets.make_counts,
     dask_ml.datasets.make_regression,
 ])
-def test_deterministic(generator):
+def test_deterministic(generator, scheduler):
     a, t = generator(chunks=100, random_state=10)
     b, u = generator(chunks=100, random_state=10)
     assert_eq(a, b)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,70 +1,60 @@
-import dask
 import dask.array as da
-import distributed
 import numpy as np
 import pytest
 import sklearn.model_selection
+import sklearn.datasets
 from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
+import dask_ml.datasets
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
 
-
-@pytest.fixture(scope='module', params=['threads', 'distributed'])
-def scheduler(request):
-    if request.param == 'distributed':
-        client = distributed.Client(set_as_default=False)
-
-    with dask.config.set(scheduler=request.param):
-        yield
-
-    if request.param == 'distributed':
-        client.close()
+X, y = dask_ml.datasets.make_classification(random_state=0, chunks=25)
 
 
-def test_incremental_basic(scheduler, xy_classification):
-    X, y = xy_classification
-    est1 = SGDClassifier(random_state=0)
-    est2 = clone(est1)
+def test_incremental_basic(scheduler):
+    with scheduler() as (s, [a, b]):
+        est1 = SGDClassifier(random_state=0)
+        est2 = clone(est1)
 
-    clf = Incremental(est1)
-    result = clf.fit(X, y, classes=[0, 1])
-    for slice_ in da.core.slices_from_chunks(X.chunks):
-        est2.partial_fit(X[slice_], y[slice_[0]], classes=[0, 1])
+        clf = Incremental(est1)
+        result = clf.fit(X, y, classes=[0, 1])
+        for slice_ in da.core.slices_from_chunks(X.chunks):
+            est2.partial_fit(X[slice_], y[slice_[0]], classes=[0, 1])
 
-    assert result is clf
+        assert result is clf
 
-    assert isinstance(result.estimator.coef_, np.ndarray)
-    np.testing.assert_array_almost_equal(result.estimator.coef_, est2.coef_)
+        assert isinstance(result.estimator.coef_, np.ndarray)
+        np.testing.assert_array_almost_equal(result.estimator.coef_,
+                                             est2.coef_)
 
-    assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
+        assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
 
-    #  Predict
-    result = clf.predict(X)
-    expected = est2.predict(X)
-    assert isinstance(result, da.Array)
-    assert_eq(result, expected)
+        #  Predict
+        result = clf.predict(X)
+        expected = est2.predict(X)
+        assert isinstance(result, da.Array)
+        assert_eq(result, expected)
 
-    # score
-    result = clf.score(X, y)
-    expected = est2.score(X, y)
-    # assert isinstance(result, da.Array)
-    assert_eq(result, expected)
+        # score
+        result = clf.score(X, y)
+        expected = est2.score(X, y)
+        # assert isinstance(result, da.Array)
+        assert_eq(result, expected)
 
-    clf = Incremental(SGDClassifier(random_state=0))
-    clf.partial_fit(X, y, classes=[0, 1])
-    assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
+        clf = Incremental(SGDClassifier(random_state=0))
+        clf.partial_fit(X, y, classes=[0, 1])
+        assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
 
 
-def test_in_gridsearch(xy_classification):
-    X, y = xy_classification
-
-    clf = Incremental(SGDClassifier(random_state=0))
-    param_grid = {'alpha': [0.1, 10]}
-    gs = sklearn.model_selection.GridSearchCV(clf, param_grid, iid=False)
-    gs.fit(X, y, classes=[0, 1])
+def test_in_gridsearch(scheduler):
+    with scheduler() as (s, [a, b]):
+        clf = Incremental(SGDClassifier(random_state=0))
+        param_grid = {'alpha': [0.1, 10]}
+        gs = sklearn.model_selection.GridSearchCV(clf, param_grid, iid=False)
+        gs.fit(X, y, classes=[0, 1])
 
 
 def test_estimator_param_raises():

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,7 +1,8 @@
 import dask.array as da
-from dask.array.utils import assert_eq
 import numpy as np
+import pytest
 import sklearn.model_selection
+from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
@@ -48,5 +49,19 @@ def test_in_gridsearch(xy_classification):
 
     clf = Incremental(SGDClassifier(random_state=0))
     param_grid = {'alpha': [0.1, 10]}
-    gs = sklearn.model_selection.GridSearchCV(clf, param_grid)
-    gs.fit(X, y)
+    gs = sklearn.model_selection.GridSearchCV(clf, param_grid, iid=False)
+    gs.fit(X, y, classes=[0, 1])
+
+
+def test_estimator_param_raises():
+    class Dummy(sklearn.base.BaseEstimator):
+        def __init__(self, estimator=42):
+            self.estimator = estimator
+
+        def fit(self, X):
+            return self
+
+    clf = Incremental(Dummy(estimator=1))
+
+    with pytest.raises(ValueError, match='used by both'):
+        clf.get_params()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -7,14 +7,12 @@ from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
-import dask_ml.datasets
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
 
-X, y = dask_ml.datasets.make_classification(random_state=0, chunks=25)
 
-
-def test_incremental_basic(scheduler):
+def test_incremental_basic(scheduler, xy_classification):
+    X, y = xy_classification
     with scheduler() as (s, [a, b]):
         est1 = SGDClassifier(random_state=0)
         est2 = clone(est1)
@@ -49,7 +47,8 @@ def test_incremental_basic(scheduler):
         assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
 
 
-def test_in_gridsearch(scheduler):
+def test_in_gridsearch(scheduler, xy_classification):
+    X, y = xy_classification
     with scheduler() as (s, [a, b]):
         clf = Incremental(SGDClassifier(random_state=0))
         param_grid = {'alpha': [0.1, 10]}


### PR DESCRIPTION
Closes https://github.com/dask/dask-ml/issues/195

Summary of changes

1. ``**kwargs`` in the Incremental constructor now refers to hyperparameters
   of `estimator`, rather than fit_kwargs
2. fit_kwargs are now passed in `fit`.

This *seemed* to work just fine with `sklearn.model_selection.GridSearchCV`.
Incremental.fit is correctly getting Dask (not NumPy) arrays.
Will try it out on a larger test now.