### PR TITLE
fix: outstanding occurrences of reblock replaced with rechunk

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -160,7 +160,7 @@ def fit(model, x, y, compute=True, **kwargs):
         assert x.chunks[0] == y.chunks[0]
     assert hasattr(model, 'partial_fit')
     if len(x.chunks[1]) > 1:
-        x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
+        x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
 
     nblocks = len(x.chunks[0])
 
@@ -196,7 +196,7 @@ def predict(model, x):
     """
     assert x.ndim == 2
     if len(x.chunks[1]) > 1:
-        x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
+        x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
     func = partial(_predict, model)
     xx = np.zeros((1, x.shape[1]), dtype=x.dtype)
     dt = model.predict(xx).dtype

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -40,15 +40,12 @@ def test_fit():
         assert result.compute().tolist() == sol.tolist()
 
 
-
 def test_fit_rechunking():
-    with dask.config.set(scheduler='single-threaded'):
-        n_classes = 2
-        X, y = make_classification(chunks=20, n_classes=n_classes)
-        X = X.rechunk({1: 10})
-        print(y.compute()[:100])
+    n_classes = 2
+    X, y = make_classification(chunks=20, n_classes=n_classes)
+    X = X.rechunk({1: 10})
 
-        assert X.numblocks[1] > 1
+    assert X.numblocks[1] > 1
 
-        clf = Incremental(SGDClassifier(max_iter=5), classes=list(range(n_classes)))
-        clf.fit(X, y)
+    clf = Incremental(SGDClassifier(max_iter=5))
+    clf.fit(X, y, classes=list(range(n_classes)))

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -1,8 +1,10 @@
 from sklearn.linear_model import SGDClassifier
 import numpy as np
 import dask
-from dask_ml._partial import fit, predict
 import dask.array as da
+from dask_ml._partial import fit, predict
+from dask_ml.datasets import make_classification
+from dask_ml.wrappers import Incremental
 
 
 x = np.array([[1, 0],
@@ -28,7 +30,7 @@ Z = da.from_array(z, chunks=(2, 2))
 
 def test_fit():
     with dask.config.set(scheduler='single-threaded'):
-        sgd = SGDClassifier()
+        sgd = SGDClassifier(max_iter=5)
 
         sgd = fit(sgd, X, Y, classes=np.array([-1, 0, 1]))
 
@@ -36,3 +38,17 @@ def test_fit():
         result = predict(sgd, Z)
         assert result.chunks == ((2, 2),)
         assert result.compute().tolist() == sol.tolist()
+
+
+
+def test_fit_rechunking():
+    with dask.config.set(scheduler='single-threaded'):
+        n_classes = 2
+        X, y = make_classification(chunks=20, n_classes=n_classes)
+        X = X.rechunk({1: 10})
+        print(y.compute()[:100])
+
+        assert X.numblocks[1] > 1
+
+        clf = Incremental(SGDClassifier(max_iter=5), classes=list(range(n_classes)))
+        clf.fit(X, y)


### PR DESCRIPTION
I was just exploring the code and noticed the occurrence of reblock in

https://github.com/dask/dask/blob/master/dask/array/learn.py#L71
https://github.com/dask/dask/blob/master/dask/array/learn.py#L101

... I looked for the implementation and couldn't find any, and later found out that it was replaced with rechunk.

See: https://github.com/dask/dask/pull/3570