### PR TITLE
MAINT: make sure warm_start=True is specified

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -284,6 +284,10 @@ class Incremental(ParallelPostFit):
     def __init__(self, estimator, scoring=None, **kwargs):
         estimator.set_params(**kwargs)
         super(Incremental, self).__init__(estimator=estimator, scoring=scoring)
+        if hasattr(estimator, 'warm_start') and not estimator.warm_start:
+            raise ValueError('Incremental requires warm_start=True so '
+                             'calls to est.fit will reuse results from '
+                             'previous calls')
 
     def fit(self, X, y=None, **fit_kwargs):
         result = fit(self.estimator, X, y, **fit_kwargs)

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -284,6 +284,7 @@ class Incremental(ParallelPostFit):
     def __init__(self, estimator, scoring=None, **kwargs):
         estimator.set_params(**kwargs)
         super(Incremental, self).__init__(estimator=estimator, scoring=scoring)
+
         if hasattr(estimator, 'warm_start') and not estimator.warm_start:
             raise ValueError('Incremental requires warm_start=True so '
                              'calls to est.fit will reuse results from '

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -8,6 +8,7 @@ import sklearn.datasets
 from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
+from sklearn.utils.testing import all_estimators
 
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
@@ -96,8 +97,12 @@ def test_warm_start_improves(func, seed=42):
     assert prob_increase >= 0.80
     assert (scores[-1] - scores[0]) / num_iter > 0.01
 
-@pytest.mark.parametrize('func', ['partial_fit', 'fit'])
-def test_warm_start_raises(func):
-    model = SGDClassifier(warm_start=False)
-    with pytest.raises(ValueError, match='requires warm_start'):
-        model = Incremental(model)
+
+def test_incremental_warm_start_raises():
+    for name, model in all_estimators():
+        if hasattr(model, 'warm_start'):
+            assert hasattr(model, 'partial_fit')
+
+            m = model(warm_start=False)
+            with pytest.raises(ValueError, match='requires warm_start'):
+                m = Incremental(m)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,5 +1,6 @@
 import dask.array as da
 import numpy as np
+import numpy.linalg as LA
 import pytest
 import sklearn.model_selection
 import sklearn.datasets
@@ -9,12 +10,13 @@ from sklearn.linear_model import SGDClassifier
 
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
+from dask_ml.datasets import make_classification
 
 
 def test_incremental_basic(scheduler, xy_classification):
     X, y = xy_classification
     with scheduler() as (s, [a, b]):
-        est1 = SGDClassifier(random_state=0)
+        est1 = SGDClassifier(random_state=0, warm_start=True)
         est2 = clone(est1)
 
         clf = Incremental(est1)
@@ -42,7 +44,7 @@ def test_incremental_basic(scheduler, xy_classification):
         # assert isinstance(result, da.Array)
         assert_eq(result, expected)
 
-        clf = Incremental(SGDClassifier(random_state=0))
+        clf = Incremental(SGDClassifier(random_state=0, warm_start=True))
         clf.partial_fit(X, y, classes=[0, 1])
         assert_estimator_equal(clf.estimator, est2, exclude=['loss_function_'])
 
@@ -50,7 +52,7 @@ def test_incremental_basic(scheduler, xy_classification):
 def test_in_gridsearch(scheduler, xy_classification):
     X, y = xy_classification
     with scheduler() as (s, [a, b]):
-        clf = Incremental(SGDClassifier(random_state=0))
+        clf = Incremental(SGDClassifier(random_state=0, warm_start=True))
         param_grid = {'alpha': [0.1, 10]}
         gs = sklearn.model_selection.GridSearchCV(clf, param_grid, iid=False)
         gs.fit(X, y, classes=[0, 1])
@@ -69,3 +71,32 @@ def test_estimator_param_raises():
 
     with pytest.raises(ValueError, match='used by both'):
         clf.get_params()
+
+
+@pytest.mark.parametrize('warm_start', [True, False])
+@pytest.mark.parametrize('func', ['partial_fit', 'fit'])
+def test_warm_start(warm_start, func, seed=42):
+    n, d = 400, 200
+    X, y = make_classification(n_features=d, n_samples=n, chunks=(n // 10, d),
+                               random_state=seed)
+
+    model = SGDClassifier(max_iter=1, warm_start=warm_start, random_state=seed)
+    if not warm_start:
+        with pytest.raises(ValueError, match='requires warm_start'):
+            model = Incremental(model)
+        return
+    model = Incremental(model)
+
+    scores = []
+    num_iter = 40
+    for iter in range(num_iter):
+        getattr(model, func)(X, y, classes=[0, 1])
+        score = model.score(X, y)
+        scores += [score]
+    scores = np.array(scores)
+
+    assert scores[0] < scores[-1]
+    prob_increase = (np.diff(scores) >= 0).sum() / len(scores)
+    avg_increase = np.diff(scores).sum() / num_iter
+    assert prob_increase > 0.65
+    assert avg_increase > 0.004


### PR DESCRIPTION
This PR implements a test to make sure that `warm_start=True` is specified if the estimator passed to `Incremental` supports it.

I found that even if `warm_start=False`, `Incremental` would reuse results to from previous calls to `fit`. This PR makes sure that relationship is specified explicitly.