### PR TITLE
Update `reblock` usage to `rechunk`

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -168,7 +168,7 @@ def fit(model, x, y, compute=True, **kwargs):
         assert x.chunks[0] == y.chunks[0]
     assert hasattr(model, 'partial_fit')
     if len(x.chunks[1]) > 1:
-        x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
+        x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
 
     nblocks = len(x.chunks[0])
 
@@ -204,7 +204,7 @@ def predict(model, x):
     """
     assert x.ndim == 2
     if len(x.chunks[1]) > 1:
-        x = x.reblock(chunks=(x.chunks[0], sum(x.chunks[1])))
+        x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
     func = partial(_predict, model)
     xx = np.zeros((1, x.shape[1]), dtype=x.dtype)
     dt = model.predict(xx).dtype


### PR DESCRIPTION
Follow-up to PR ( https://github.com/dask/dask-ml/pull/187 )
Addresses https://github.com/dask/dask/issues/3569
Replaces https://github.com/dask/dask/pull/3570

The `reblock` method was an older method used by Dask Array. It has long since been renamed to `rechunk`. This updates `dask_ml`'s `_partial` module to use `rechunk` instead.

cc @convexset @mrocklin