### PR TITLE
Call map_blocks with dtype in ParallelPostFit.fit

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -133,7 +133,7 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
         transform = self._check_method('transform')
 
         if isinstance(X, da.Array):
-            return X.map_blocks(transform)
+            return X.map_blocks(transform, dtype=X.dtype)
         elif isinstance(X, dd._Frame):
             return _apply_partitionwise(X, transform)
         else:


### PR DESCRIPTION
Follow-up to comment ( https://github.com/dask/dask-ml/issues/197#issuecomment-396105384 )

Instead of letting `map_blocks` guess the `dtype` needed by `transform`, provide it the `dtype` of `X`. This may not always be right, but is more likely right than wrong. Further it gives the user a mechanism to fix the `dtype` returned by `map_blocks` when it's heuristics for detection fail, which is an improvement over the current behavior that does not supply such an option.