### PR TITLE
TST: test the scoring kwarg for Incremental

### DIFF
--- a/dask_ml/metrics/__init__.py
+++ b/dask_ml/metrics/__init__.py
@@ -14,5 +14,6 @@ from .classification import (  # noqa
 
 from .scorer import (  # noqa
     get_scorer,
+    check_scoring,
     SCORERS,
 )

--- a/dask_ml/metrics/scorer.py
+++ b/dask_ml/metrics/scorer.py
@@ -1,5 +1,6 @@
 import six
 from sklearn.metrics import make_scorer
+from sklearn.metrics.scorer import check_scoring as sklearn_check_scoring
 
 from . import (
     accuracy_score,
@@ -38,13 +39,28 @@ def get_scorer(scoring, compute=True):
     # and don't have back-compat code
     if isinstance(scoring, six.string_types):
         try:
-            func = SCORERS[scoring]
-            scorer = lambda est, X, y: func(est, X, y)
+            scorer = SCORERS[scoring]
         except KeyError:
             raise ValueError('{} is not a valid scoring value. '
                              'Valid options are {}'.format(scoring,
                                                            sorted(SCORERS)))
     else:
-        scorer = lambda est, X, y: scoring(est.predict(X), y)
+        scorer = scoring
 
     return scorer
+
+
+def check_scoring(estimator, scoring=None, **kwargs):
+    sklearn_check_scoring(estimator, scoring=scoring, **kwargs)
+    if callable(scoring):
+        # Heuristic to ensure user has not passed a metric
+        module = getattr(scoring, '__module__', None)
+        if hasattr(module, 'startswith') and \
+           module.startswith('dask_ml.metrics.') and \
+           not module.startswith('dask_ml.metrics.scorer') and \
+           not module.startswith('dask_ml.metrics.tests.'):
+            raise ValueError('scoring value %r looks like it is a metric '
+                             'function rather than a scorer. A scorer should '
+                             'require an estimator as its first parameter. '
+                             'Please use `make_scorer` to convert a metric '
+                             'to a scorer.' % scoring)

--- a/dask_ml/metrics/scorer.py
+++ b/dask_ml/metrics/scorer.py
@@ -38,12 +38,13 @@ def get_scorer(scoring, compute=True):
     # and don't have back-compat code
     if isinstance(scoring, six.string_types):
         try:
-            scorer = SCORERS[scoring]
+            func = SCORERS[scoring]
+            scorer = lambda est, X, y: func(est, X, y)
         except KeyError:
             raise ValueError('{} is not a valid scoring value. '
                              'Valid options are {}'.format(scoring,
                                                            sorted(SCORERS)))
     else:
-        scorer = scoring
+        scorer = lambda est, X, y: scoring(est.predict(X), y)
 
     return scorer

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -10,7 +10,7 @@ import sklearn.base
 
 from ._partial import fit
 from ._utils import copy_learned_attributes
-from .metrics import get_scorer
+from .metrics import get_scorer, check_scoring
 
 
 logger = logging.getLogger(__name__)
@@ -285,6 +285,7 @@ class Incremental(ParallelPostFit):
         super(Incremental, self).__init__(estimator=estimator, scoring=scoring)
 
     def fit(self, X, y=None, **fit_kwargs):
+        check_scoring(self.estimator, self.scoring)
         result = fit(self.estimator, X, y, **fit_kwargs)
 
         # Copy the learned attributes over to self

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -158,9 +158,8 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
                 return self.estimator.score(X, y)
         """
         if self.scoring:
-            scoring = self.scoring
-            scorer = get_scorer(scoring)
-            return scorer(self.estimator, X, y)
+            scorer = get_scorer(self.scoring)
+            return scorer(self, X, y)
         else:
             return self.estimator.score(X, y)
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -9,6 +9,7 @@ from sklearn.linear_model import SGDClassifier
 
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
+from dask_ml.metrics import accuracy_score
 
 
 def test_incremental_basic(scheduler, xy_classification):
@@ -69,3 +70,21 @@ def test_estimator_param_raises():
 
     with pytest.raises(ValueError, match='used by both'):
         clf.get_params()
+
+
+def test_scoring(scheduler, xy_classification):
+    X, y = xy_classification
+    with scheduler() as (s, [a, b]):
+        clf = Incremental(SGDClassifier(), scoring=accuracy_score)
+        clf.fit(X, y, classes=np.unique(y))
+        clf.score(X, y)
+        clf.estimator.score(X, y)
+
+
+def test_scoring_string(scheduler, xy_classification):
+    X, y = xy_classification
+    with scheduler() as (s, [a, b]):
+        clf = Incremental(SGDClassifier(), scoring='accuracy')
+        clf.fit(X, y, classes=np.unique(y))
+        clf.score(X, y)
+        clf.estimator.score(X, y)


### PR DESCRIPTION
I specified a `scoring` keyword arg to `Incremental` and ran into a bug: if I specified a `scoring` keyword arg, then an if-statement in `get_scorer` wasn't working or tested. This resolves that.

The tests primarily test to make sure no errors are thrown.