### PR TITLE
MAINT: revert back to sklearn's train_test_split if not all dask arrays

### DIFF
--- a/dask_ml/model_selection/_split.py
+++ b/dask_ml/model_selection/_split.py
@@ -12,6 +12,7 @@ from sklearn.model_selection._split import (
     _validate_shuffle_split_init,
     BaseCrossValidator,
 )
+import sklearn.model_selection as ms
 
 from dask_ml.utils import check_array
 
@@ -270,7 +271,11 @@ def train_test_split(*arrays, **options):
     if not shuffle:
         raise NotImplementedError
 
-    assert all(isinstance(arr, da.Array) for arr in arrays)
+    if not all(isinstance(arr, da.Array) for arr in arrays):
+        return ms.train_test_split(*arrays, test_size=test_size,
+                                   train_size=train_size,
+                                   random_state=random_state,
+                                   shuffle=shuffle)
 
     splitter = ShuffleSplit(n_splits=1, test_size=test_size,
                             train_size=train_size, blockwise=blockwise,

--- a/tests/model_selection/test_split.py
+++ b/tests/model_selection/test_split.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.datasets import make_regression
+from sklearn.datasets import fetch_20newsgroups
 
 import dask_ml.model_selection
 
@@ -10,6 +11,19 @@ import dask_ml.model_selection
 X, y = make_regression(n_samples=110, n_features=5)
 dX = da.from_array(X, 50)
 dy = da.from_array(y, 50)
+
+
+def test_20_newsgroups():
+    data = fetch_20newsgroups()
+    X, y = data.data, data.target
+    r = dask_ml.model_selection.train_test_split(X, y)
+    X_train, X_test, y_train, y_test = r
+    for X in [X_train, X_test]:
+        assert isinstance(X, list)
+        assert isinstance(X[0], str)
+    for y in [y_train, y_test]:
+        assert isinstance(y, np.ndarray)
+        assert y.dtype == int
 
 
 def test_blockwise_shufflesplit():

--- a/tests/model_selection/test_split.py
+++ b/tests/model_selection/test_split.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 from sklearn.datasets import make_regression
 from sklearn.datasets import fetch_20newsgroups
+import six
 
 import dask_ml.model_selection
 
@@ -20,7 +21,7 @@ def test_20_newsgroups():
     X_train, X_test, y_train, y_test = r
     for X in [X_train, X_test]:
         assert isinstance(X, list)
-        assert isinstance(X[0], str)
+        assert isinstance(X[0], six.string_types)
     for y in [y_train, y_test]:
         assert isinstance(y, np.ndarray)
         assert y.dtype == int


### PR DESCRIPTION
Fixes #215.

I ran into this while creating an example for https://github.com/dask/dask-searchcv/pull/72 that required the 20 newsgroups dataset. This is the easiest fix.