### PR TITLE
Fix PR links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,4 +207,5 @@ def setup(app):
 
 extlinks = {
     'issue': ('https://github.com/dask/dask-ml/issues/%s', 'GH#'),
+    'pr': ('https://github.com/dask/dask-ml/pull/%s', 'GH#'),
 }


### PR DESCRIPTION
Currently pull request links formatted like `` :pr:`<number>` `` aren't rendered correctly in the docs (e.g. the changelog). This PR adds to `extlinks` in `conf.py` for these pull request links. 