### PR TITLE
MAINT: call model.fit directly if ndarrays passed to partial_fit

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -167,7 +167,7 @@ def fit(model, x, y, compute=True, **kwargs):
     if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
         if hasattr(model, 'estimator'):
             estimator = _partial_fit(model.estimator, x, y, kwargs=kwargs)
-            model.estimator = estimator
+            copy_learned_attributes(estimator, model)
             return model
         return _partial_fit(model, x, y, kwargs=kwargs)
     if not (isinstance(x, da.Array) and

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -166,7 +166,9 @@ def fit(model, x, y, compute=True, **kwargs):
     assert x.ndim == 2
     if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
         if hasattr(model, 'estimator'):
-            return _partial_fit(model.estimator, x, y, kwargs=kwargs)
+            estimator = _partial_fit(model.estimator, x, y, kwargs=kwargs)
+            model.estimator = estimator
+            return model
         return _partial_fit(model, x, y, kwargs=kwargs)
     if not (isinstance(x, da.Array) and
             (y is None or isinstance(y, da.Array))):

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -164,10 +164,14 @@ def fit(model, x, y, compute=True, **kwargs):
     dask.array<x_11, shape=(400,), chunks=((100, 100, 100, 100),), dtype=int64>
     """
     assert x.ndim == 2
-    if isinstance(x, np.ndarray):
-        x = da.from_array(x, chunks=x.shape)
-    if isinstance(y, np.ndarray):
-        y = da.from_array(y, chunks=y.shape)
+    if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
+        if hasattr(model, 'estimator'):
+            return _partial_fit(model.estimator, x, y, kwargs=kwargs)
+        return _partial_fit(model, x, y, kwargs=kwargs)
+    if not (isinstance(x, da.Array) and
+            (y is None or isinstance(y, da.Array))):
+        raise ValueError("X and y should be both np.ndarrays or both "
+                         "dask.array.Arrays, not a mix.")
     if y is not None:
         assert y.ndim == 1
         assert x.chunks[0] == y.chunks[0]

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -55,6 +55,17 @@ def test_fit(array_lib, model_lib):
         else:
             raise ValueError
 
+        if model_lib == "dask-ml":
+            assert isinstance(est, Incremental)
+            assert hasattr(est.estimator, "coef_")
+        elif model_lib == "sklearn":
+            assert isinstance(est, SGDClassifier)
+            assert hasattr(est, "coef_")
+        else:
+            raise ValueError
+
+        assert hasattr(est, "coef_")
+
 
 @pytest.mark.parametrize("model_lib", ["dask-ml", "sklearn"])
 def test_fit_need_same_input_types(model_lib):

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -5,6 +5,7 @@ import dask.array as da
 from dask_ml._partial import fit, predict
 from dask_ml.datasets import make_classification
 from dask_ml.wrappers import Incremental
+from dask.array.utils import assert_eq
 
 import pytest
 
@@ -30,25 +31,39 @@ Y = da.from_array(y, chunks=(3,))
 Z = da.from_array(z, chunks=(2, 2))
 
 
-@pytest.mark.parametrize("x_,y_,z_", [(x, y, z), (X, Y, Z)])
-def test_fit(x_, y_, z_):
+@pytest.mark.parametrize("array_lib", ['numpy', 'dask.array'])
+@pytest.mark.parametrize("model_lib", ["dask-ml", "sklearn"])
+def test_fit(array_lib, model_lib):
     with dask.config.set(scheduler='single-threaded'):
-        sgd = SGDClassifier(max_iter=5)
-        sgd = fit(sgd, x_, y_, classes=np.array([-1, 0, 1]))
+        arrays = {'numpy': [x, y, z], 'dask.array': [X, Y, Z]}
+        models = {'sklearn': SGDClassifier(max_iter=5),
+                  'dask-ml': Incremental(SGDClassifier(max_iter=5))}
+        x_, y_, z_ = arrays[array_lib]
+        est = models[model_lib]
+        est = fit(est, x_, y_, classes=np.array([-1, 0, 1]))
 
-        sol = sgd.predict(z)
-        result = predict(sgd, z_)
+        sol = est.predict(z)
+        result = predict(est, z_)
 
-        if isinstance(z_, da.Array):
+        if array_lib == "dask.array":
             assert result.chunks == ((2, 2),)
             assert isinstance(result, da.Array)
-            assert result.compute().tolist() == sol.tolist()
-        elif isinstance(z_, np.ndarray):
+            assert assert_eq(result, sol)
+        elif array_lib == "numpy":
             assert isinstance(result, np.ndarray)
-            assert result.tolist() == sol.tolist()
+            assert assert_eq(result, sol)
         else:
             raise ValueError
 
+
+@pytest.mark.parametrize("model_lib", ["dask-ml", "sklearn"])
+def test_fit_need_same_input_types(model_lib):
+    with dask.config.set(scheduler='single-threaded'):
+        models = {'sklearn': SGDClassifier(max_iter=5),
+                  'dask-ml': Incremental(SGDClassifier(max_iter=5))}
+        est = models[model_lib]
+        with pytest.raises(ValueError, match='X and y should be both'):
+            est = fit(est, X, y, classes=np.array([-1, 0, 1]))
 
 def test_fit_rechunking():
     n_classes = 2

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -55,6 +55,7 @@ def test_fit(array_lib, model_lib):
         else:
             raise ValueError
 
+        assert hasattr(est, "coef_")
         if model_lib == "dask-ml":
             assert isinstance(est, Incremental)
             assert hasattr(est.estimator, "coef_")
@@ -63,8 +64,6 @@ def test_fit(array_lib, model_lib):
             assert hasattr(est, "coef_")
         else:
             raise ValueError
-
-        assert hasattr(est, "coef_")
 
 
 @pytest.mark.parametrize("model_lib", ["dask-ml", "sklearn"])

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -75,6 +75,7 @@ def test_fit_need_same_input_types(model_lib):
         with pytest.raises(ValueError, match='X and y should be both'):
             est = fit(est, X, y, classes=np.array([-1, 0, 1]))
 
+
 def test_fit_rechunking():
     n_classes = 2
     X, y = make_classification(chunks=20, n_classes=n_classes)


### PR DESCRIPTION
If `partial_fit` is called with NumPy arrays, why don't we call `partial_fit` directly with those arrays instead of making a new dask array?

I think this is the bug behind #221: `_partial_fit` would needlessly launch dask tasks.