### PR TITLE
Adds LabelEncoder

### DIFF
--- a/dask_ml/preprocessing/__init__.py
+++ b/dask_ml/preprocessing/__init__.py
@@ -9,3 +9,4 @@ from .data import (  # noqa
     DummyEncoder,
     OrdinalEncoder,
 )
+from .label import LabelEncoder # noqa

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -1,0 +1,52 @@
+from __future__ import division
+
+from operator import getitem
+
+import dask.array as da
+import dask.dataframe as dd
+import numpy as np
+from sklearn.preprocessing import label as sklabel
+from sklearn.utils.validation import check_is_fitted
+
+
+class LabelEncoder(sklabel.LabelEncoder):
+
+    __doc__ = sklabel.LabelEncoder.__doc__
+
+    def fit(self, y):
+        if isinstance(y, dd.Series):
+            y = da.asarray(y)
+
+        if isinstance(y, da.Array):
+            classes_ = da.unique(y)
+            classes_ = classes_.compute()
+        else:
+            classes_ = np.unique(y)
+
+        self.classes_ = classes_
+
+        return self
+
+    def fit_transform(self, y):
+        return self.fit(y).transform(y)
+
+    def transform(self, y):
+        check_is_fitted(self, 'classes_')
+        if isinstance(y, dd.Series):
+            y = da.asarray(y)
+
+        if isinstance(y, da.Array):
+            return y.map_blocks(lambda b: np.searchsorted(self.classes_, b),
+                                dtype=self.classes_.dtype)
+        else:
+            return np.searchsorted(self.classes_, y)
+
+    def inverse_transform(self, y):
+        check_is_fitted(self, 'classes_')
+
+        if isinstance(y, da.Array):
+            return y.map_blocks(lambda block: getitem(self.classes_, block),
+                                dtype=self.classes_.dtype)
+        else:
+            y = np.asarray(y)
+            return self.classes_[y]

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -43,6 +43,8 @@ class LabelEncoder(sklabel.LabelEncoder):
 
     def inverse_transform(self, y):
         check_is_fitted(self, 'classes_')
+        if isinstance(y, dd.Series):
+            y = da.asarray(y)
 
         if isinstance(y, da.Array):
             return y.map_blocks(lambda block: getitem(self.classes_, block),

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Enhancements
 ------------
 
 - Added ``sample_weight`` support for :meth:`dask_ml.metrics.accuracy_score`. (:pr:`217`)
+- Added :class:`dask_ml.preprocessing.LabelEncoder`. (:pr:`226`)
 
 
 Version 0.6.0

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -127,6 +127,7 @@ compatible estimators with Dask arrays.
    preprocessing.Categorizer
    preprocessing.DummyEncoder
    preprocessing.OrdinalEncoder
+   preprocessing.LabelEncoder
 
 
 :mod:`dask_ml.metrics`: Metrics

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -21,6 +21,7 @@ scikit-learn counterparts.
    QuantileTransformer
    RobustScaler
    StandardScaler
+   LabelEncoder
 
 These can be used just like the scikit-learn versions, except that:
 

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -61,7 +61,8 @@ def test_sample_weight(metric_pairs, normalize):
     sample_weight_np = np.random.random_sample(size[0])
     sample_weight_da = da.from_array(sample_weight_np, chunks=25)
 
-    result = m1(a, b, sample_weight=sample_weight_da, normalize=normalize, compute=True)
+    result = m1(a, b, sample_weight=sample_weight_da, normalize=normalize,
+                compute=True)
     expected = m2(a, b, sample_weight=sample_weight_np, normalize=normalize)
     assert abs(result - expected) < 1e-5
 
@@ -79,4 +80,5 @@ def test_sample_weight_raises(metric_pairs, normalize):
     sample_weight_da = da.from_array(sample_weight_np, chunks=25)
 
     with pytest.raises(NotImplementedError):
-        m1(a, b, sample_weight=sample_weight_da, normalize=normalize, compute=True)
+        m1(a, b, sample_weight=sample_weight_da, normalize=normalize,
+           compute=True)

--- a/tests/preprocessing/test_label.py
+++ b/tests/preprocessing/test_label.py
@@ -64,8 +64,9 @@ class TestLabelEncoder(object):
         assert_eq_ar(a.transform(array).compute(),
                      b.transform(array.compute()))
 
-    def test_inverse_transform(self):
+    @pytest.mark.parametrize('array', [y, s])
+    def test_inverse_transform(self, array):
 
         a = dpp.LabelEncoder()
-        assert_eq_ar(a.inverse_transform(a.fit_transform(y)).compute(),
-                     y.compute())
+        assert_eq_ar(a.inverse_transform(a.fit_transform(array)).compute(),
+                     array.compute())

--- a/tests/preprocessing/test_label.py
+++ b/tests/preprocessing/test_label.py
@@ -1,0 +1,71 @@
+import pytest
+import sklearn.preprocessing as spp
+
+import dask.array as da
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+from dask.array.utils import assert_eq as assert_eq_ar
+
+import dask_ml.preprocessing as dpp
+from dask_ml.utils import assert_estimator_equal
+
+
+choices = np.array(['a', 'b', 'c'], dtype=str)
+y = np.random.choice(choices, 100)
+y = da.from_array(y, chunks=13)
+s = dd.from_array(y)
+
+
+@pytest.fixture
+def pandas_series():
+    y = np.random.choice(['a', 'b', 'c'], 100)
+    return pd.Series(y)
+
+
+@pytest.fixture
+def dask_array(pandas_series):
+    return da.from_array(pandas_series, chunks=5)
+
+
+class TestLabelEncoder(object):
+    def test_basic(self):
+        a = dpp.LabelEncoder()
+        b = spp.LabelEncoder()
+
+        a.fit(y)
+        b.fit(y.compute())
+        assert_estimator_equal(a, b)
+
+    def test_input_types(self, dask_array, pandas_series):
+        a = dpp.LabelEncoder()
+        b = spp.LabelEncoder()
+
+        assert_estimator_equal(a.fit(dask_array),
+                               b.fit(pandas_series))
+
+        assert_estimator_equal(a.fit(pandas_series),
+                               b.fit(pandas_series))
+
+        assert_estimator_equal(a.fit(pandas_series.values),
+                               b.fit(pandas_series))
+
+        assert_estimator_equal(a.fit(dask_array),
+                               b.fit(pandas_series.values))
+
+    @pytest.mark.parametrize('array', [y, s])
+    def test_transform(self, array):
+        a = dpp.LabelEncoder()
+        b = spp.LabelEncoder()
+
+        a.fit(array)
+        b.fit(array.compute())
+
+        assert_eq_ar(a.transform(array).compute(),
+                     b.transform(array.compute()))
+
+    def test_inverse_transform(self):
+
+        a = dpp.LabelEncoder()
+        assert_eq_ar(a.inverse_transform(a.fit_transform(y)).compute(),
+                     y.compute())

--- a/tests/preprocessing/test_label.py
+++ b/tests/preprocessing/test_label.py
@@ -68,5 +68,5 @@ class TestLabelEncoder(object):
     def test_inverse_transform(self, array):
 
         a = dpp.LabelEncoder()
-        assert_eq_ar(a.inverse_transform(a.fit_transform(array)).compute(),
-                     array.compute())
+        assert_eq_ar(a.inverse_transform(a.fit_transform(array)),
+                     da.asarray(array))


### PR DESCRIPTION
This PR adds `LabelEncoder` as a drop-in replacement for `sklearn.preprocessing.LabelEncoder`.