### PR TITLE
Replaced channels with queues and other misc. cleanup.

### DIFF
--- a/docs/source/examples/tensorflow.ipynb
+++ b/docs/source/examples/tensorflow.ipynb
@@ -45,12 +45,10 @@
     "import dask.array as da\n",
     "from dask import delayed\n",
     "from dask_tensorflow import start_tensorflow\n",
-    "from distributed import Client, progress\n",
+    "from distributed import Client, progress, get_worker, worker_client, Queue\n",
     "import dask.dataframe as dd\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "import dask.array as da\n",
-    "from dask import delayed"
+    "import tensorflow as tf"
    ]
   },
   {
@@ -194,7 +192,6 @@
    },
    "outputs": [],
    "source": [
-    "from dask_tensorflow import start_tensorflow\n",
     "tf_spec, dask_spec = start_tensorflow(client, ps=1, worker=4, scorer=1)"
    ]
   },
@@ -344,8 +341,8 @@
    "outputs": [],
    "source": [
     "def ps_task():\n",
-    "    with local_client() as c:\n",
-    "        c.worker.tensorflow_server.join()"
+    "    worker = get_worker()\n",
+    "    worker.tensorflow_server.join()"
    ]
   },
   {
@@ -357,13 +354,14 @@
    "outputs": [],
    "source": [
     "def scoring_task():\n",
-    "    with local_client() as c:\n",
+    "    with worker_client() as c:\n",
     "        # Scores Channel\n",
-    "        scores = c.channel('scores', maxlen=10)\n",
+    "        scores = Queue('scores')\n",
     "\n",
     "        # Make Model\n",
-    "        server = c.worker.tensorflow_server\n",
-    "        sess, _, _, _, _, cross_entropy = model(c.worker.tensorflow_server)\n",
+    "        worker = get_worker()\n",
+    "        server = worker.tensorflow_server\n",
+    "        sess, x, y_, _, _, cross_entropy = model(server)\n",
     "\n",
     "        # Testing Data\n",
     "        from tensorflow.examples.tutorials.mnist import input_data\n",
@@ -374,7 +372,7 @@
     "        # Main Loop\n",
     "        while True:\n",
     "            score = sess.run(cross_entropy, feed_dict=test_data)\n",
-    "            scores.append(float(score))\n",
+    "            scores.put(float(score))\n",
     "\n",
     "            time.sleep(1)"
    ]
@@ -386,20 +384,22 @@
    "outputs": [],
    "source": [
     "def worker_task():\n",
-    "    with local_client() as c:\n",
-    "        scores = c.channel('scores')\n",
+    "    with worker_client() as c:\n",
+    "        scores = Queue('scores')\n",
     "        num_workers = replicas_to_aggregate = len(dask_spec['worker'])\n",
     "\n",
-    "        server = c.worker.tensorflow_server\n",
-    "        queue = c.worker.tensorflow_queue\n",
+    "        worker = get_worker()\n",
+    "        server = worker.tensorflow_server\n",
+    "        tf_queue = worker.tensorflow_queue\n",
     "\n",
     "        # Make model\n",
-    "        sess, x, y_, train_step, global_step, _= model(c.worker.tensorflow_server)\n",
+    "        sess, x, y_, train_step, global_step, _= model(server)\n",
     "\n",
     "        # Main loop\n",
-    "        while not scores or scores.data[-1] > 1000:\n",
+    "        sc = scores.get()\n",
+    "        while not scores or sc > 1000:\n",
     "            try:\n",
-    "                batch = queue.get(timeout=0.5)\n",
+    "                batch = tf_queue.get(timeout=0.5)\n",
     "            except Empty:\n",
     "                continue\n",
     "\n",
@@ -426,18 +426,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transfer_dask_to_tensorflow(batch):\n",
+    "    worker = get_worker()\n",
+    "    worker.tensorflow_queue.put(batch)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from distributed.worker_client import get_worker\n",
-    "\n",
-    "def transfer_dask_to_tensorflow(batch):\n",
-    "    worker = get_worker()\n",
-    "    worker.tensorflow_queue.put(batch)\n",
-    "\n",
-    "dump = client.map(transfer_dask_to_tensorflow, batches,\n",
-    "                  workers=dask_spec['worker'], pure=False)\n"
+    "scores = Queue('scores')\n",
+    "score = scores.get()\n",
+    "while score > 1000:\n",
+    "    print(score)\n",
+    "    dump = client.map(transfer_dask_to_tensorflow, batches,\n",
+    "                      workers=dask_spec['worker'], pure=False)\n",
+    "    score = scores.get()"
    ]
   }
  ],
@@ -457,7 +467,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The current tf example code doesn't quite work as-is.  It also uses the outdated "channel" approach which dask now uses queues for.  This is a tiny change to bring things up to working order.
