### PR TITLE
MAINT: ndarrays for score (and move ndarray logic from partial_fit to fit)

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -11,6 +11,7 @@ import sklearn.base
 from ._partial import fit
 from ._utils import copy_learned_attributes
 from .metrics import get_scorer, check_scoring
+from sklearn.metrics import get_scorer as sklearn_get_scorer
 
 
 logger = logging.getLogger(__name__)
@@ -158,7 +159,10 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
                 return self.estimator.score(X, y)
         """
         if self.scoring:
-            scorer = get_scorer(self.scoring)
+            if not dask.is_dask_collection(X) and not dask.is_dask_collection(y):
+                scorer = sklearn_get_scorer(self.scoring)
+            else:
+                scorer = get_scorer(self.scoring)
             return scorer(self, X, y)
         else:
             return self.estimator.score(X, y)

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -159,7 +159,8 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
                 return self.estimator.score(X, y)
         """
         if self.scoring:
-            if not dask.is_dask_collection(X) and not dask.is_dask_collection(y):
+            if (not dask.is_dask_collection(X) and
+                    not dask.is_dask_collection(y)):
                 scorer = sklearn_get_scorer(self.scoring)
             else:
                 scorer = get_scorer(self.scoring)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -99,7 +99,7 @@ def test_scoring_string(scheduler, xy_classification, scoring):
         clf.estimator.score(X, y)
 
 
-def test_partial_fit():
+def test_ndarrays():
     X = np.ones((10, 5))
     y = np.ones(10)
 
@@ -107,6 +107,7 @@ def test_partial_fit():
     inc = Incremental(sgd)
 
     inc.partial_fit(X, y, classes=[0, 1])
+    inc.fit(X, y)
 
     assert inc.estimator is sgd
     assert (sgd.predict(X) == y).all()

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import SGDClassifier
 from dask_ml.wrappers import Incremental
 from dask_ml.utils import assert_estimator_equal
 import dask_ml.metrics
-from dask_ml.metrics.scorer import check_scoring, SCORERS
+from dask_ml.metrics.scorer import check_scoring
 
 
 def test_incremental_basic(scheduler, xy_classification):


### PR DESCRIPTION
**What does this PR implement?**
Two changes:

1. Modify `ParallelPostFit` to accepts score ndarrays if passed by using sklearn's `get_scorer`.
2. Move the logic in #236 to `Incremental.fit` (which works because `partial_fit` calls `fit`).