### PR TITLE
Use default scheduler sniffing logic from dask

### DIFF
--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -10,7 +10,6 @@ import numpy as np
 import dask
 from dask.base import tokenize
 from dask.delayed import delayed
-from dask.threaded import get as threaded_get
 from dask.utils import derived_from
 from sklearn import model_selection
 from sklearn.base import (is_classifier, clone, BaseEstimator,
@@ -839,9 +838,13 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
 
         n_jobs = _normalize_n_jobs(self.n_jobs)
         scheduler = dask.base.get_scheduler(
-                scheduler=self.scheduler if isinstance(self.scheduler, str) else None,
-                get=self.scheduler if callable(self.scheduler) else None
-            ) or dask.threaded.get
+            scheduler=(self.scheduler
+                       if isinstance(self.scheduler, str)
+                       else None),
+            get=self.scheduler if callable(self.scheduler) else None)
+
+        if not scheduler:
+            scheduler = dask.threaded.get
         if scheduler is dask.threaded.get and n_jobs == 1:
             scheduler = dask.local.get_sync
 

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -666,42 +666,6 @@ def _normalize_n_jobs(n_jobs):
     return n_jobs
 
 
-_scheduler_aliases = {'sync': 'synchronous',
-                      'sequential': 'synchronous',
-                      'threaded': 'threading'}
-
-
-def _normalize_scheduler(scheduler, n_jobs):
-    # Default
-    if scheduler is None:
-        scheduler = dask.context._globals.get('get')
-        if scheduler is None:
-            scheduler = dask.get if n_jobs == 1 else threaded_get
-        return scheduler
-
-    # Get-functions
-    if callable(scheduler):
-        return scheduler
-
-    # Support name aliases
-    if isinstance(scheduler, str):
-        scheduler = _scheduler_aliases.get(scheduler, scheduler)
-
-    if scheduler in ('threading', 'multiprocessing') and n_jobs == 1:
-        scheduler = dask.get
-    elif scheduler == 'threading':
-        scheduler = threaded_get
-    elif scheduler == 'multiprocessing':
-        from dask.multiprocessing import get as scheduler
-    elif scheduler == 'synchronous':
-        scheduler = dask.get
-    elif hasattr(scheduler, 'get'):
-        scheduler = scheduler.get
-    else:
-        raise ValueError("Unknown scheduler: %r." % scheduler)
-    return scheduler
-
-
 class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     """Base class for hyper parameter search with cross-validation."""
 
@@ -874,7 +838,12 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         self.n_splits_ = n_splits
 
         n_jobs = _normalize_n_jobs(self.n_jobs)
-        scheduler = _normalize_scheduler(self.scheduler, n_jobs)
+        scheduler = dask.base.get_scheduler(
+                scheduler=self.scheduler if isinstance(self.scheduler, str) else None,
+                get=self.scheduler if callable(self.scheduler) else None
+            ) or dask.threaded.get
+        if scheduler is dask.threaded.get and n_jobs == 1:
+            scheduler = dask.local.get_sync
 
         out = scheduler(dsk, keys, num_workers=n_jobs)
 

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -15,7 +15,6 @@ import dask.array as da
 from dask.base import tokenize
 from dask.callbacks import Callback
 from dask.delayed import delayed
-from dask.threaded import get as get_threading
 from dask.utils import tmpdir
 
 from sklearn.datasets import make_classification, load_iris
@@ -629,19 +628,15 @@ def test_normalize_n_jobs():
         _normalize_n_jobs('not an integer')
 
 
-@pytest.mark.parametrize('scheduler,n_jobs,get',
-                         [(None, 4, get_threading),
-                          ('threading', 4, get_threading),
-                          ('threading', 1, dask.get),
-                          ('synchronous', 4, dask.get),
-                          ('sync', 4, dask.get),
-                          ('multiprocessing', 4, None),
-                          (dask.get, 4, dask.get)])
-def test_scheduler_param(scheduler, n_jobs, get):
-    if scheduler == 'multiprocessing':
-        mp = pytest.importorskip('dask.multiprocessing')
-        get = mp.get
-
+@pytest.mark.parametrize('scheduler,n_jobs',
+                         [(None, 4),
+                          ('threading', 4),
+                          ('threading', 1),
+                          ('synchronous', 4),
+                          ('sync', 4),
+                          ('multiprocessing', 4),
+                          (dask.get, 4)])
+def test_scheduler_param(scheduler, n_jobs):
     X, y = make_classification(n_samples=100, n_features=10, random_state=0)
     gs = dcv.GridSearchCV(MockClassifier(), {'foo_param': [0, 1, 2]}, cv=3,
                           scheduler=scheduler, n_jobs=n_jobs)


### PR DESCRIPTION
This removes the _normalize_scheduler function from dask_searchcv and
some of the scheduling names (threaded, sequential) and replaces them
with the Dask logic.

This both unifies logic across projects and also lets the distributed
scheduler take over when it is set as default.

Fixes https://github.com/dask/dask-ml/issues/249