### PR TITLE
ENH: max_iter for Incremental

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -323,6 +323,11 @@ class Incremental(ParallelPostFit):
            a single NumPy array, which may exhaust the memory of your worker.
            You probably want to always specify `scoring`.
 
+    max_iter : int, default 1
+        The maximum number of passes over the training data (aka epochs).
+        It only impacts the behavior in the ``fit`` method, and not
+        `partial_fit`.
+
     Attributes
     ----------
     estimator_ : Estimator
@@ -351,6 +356,10 @@ class Incremental(ParallelPostFit):
     >>> gs.fit(X, y, classes=[0, 1])
     """
 
+    def __init__(self, estimator=None, scoring=None, max_iter=1):
+        self.max_iter = max_iter
+        super(Incremental, self).__init__(estimator=estimator, scoring=scoring)
+
     @property
     def _postfit_estimator(self):
         check_is_fitted(self, 'estimator_')
@@ -369,7 +378,14 @@ class Incremental(ParallelPostFit):
 
     def fit(self, X, y=None, **fit_kwargs):
         estimator = sklearn.base.clone(self.estimator)
-        self._fit_for_estimator(estimator, X, y, **fit_kwargs)
+
+        for i in range(self.max_iter):
+            logger.info("Starting iteration %d", i)
+            start = tic()
+            self._fit_for_estimator(estimator, X, y, **fit_kwargs)
+            stop = tic()
+            logger.info("Finished iteration %d, %0.2f", i, stop - start)
+
         return self
 
     def partial_fit(self, X, y=None, **fit_kwargs):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Enhancements
 - Added ``sample_weight`` support for :meth:`dask_ml.metrics.accuracy_score`. (:pr:`217`)
 - Improved performance of training on :class:`dask_ml.cluster.SpectralClustering` (:pr:`152`)
 - Added :class:`dask_ml.preprocessing.LabelEncoder`. (:pr:`226`)
+- Added the ``max_iter`` parameter to :class:`dask_ml.wrappers.Incremental` to make multiple passes over the training data (:pr:`258`)
 
 API Breaking Changes
 --------------------

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -18,16 +18,19 @@ def test_get_params():
     result = clf.get_params()
 
     assert 'estimator__max_iter' in result
+    assert 'max_iter' in result
     assert result['scoring'] is None
 
 
 def test_set_params():
     clf = Incremental(SGDClassifier())
     clf.set_params(**{'scoring': 'accuracy',
+                      'max_iter': 10,
                       'estimator__max_iter': 20})
     result = clf.get_params()
 
     assert result['estimator__max_iter'] == 20
+    assert result['max_iter'] == 10
     assert result['scoring'] == 'accuracy'
 
 
@@ -68,6 +71,16 @@ def test_incremental_basic(scheduler, xy_classification):
         clf.partial_fit(X, y, classes=[0, 1])
         assert_estimator_equal(clf.estimator_, est2,
                                exclude=['loss_function_'])
+
+
+def test_max_iter(scheduler, xy_classification):
+    X, y = xy_classification
+
+    est = SGDClassifier(random_state=0, tol=1e-3)
+    clf = Incremental(est, max_iter=5)
+
+    with scheduler():
+        clf.fit(X, y, classes=[0, 1])
 
 
 def test_in_gridsearch(scheduler, xy_classification):


### PR DESCRIPTION
See https://github.com/dask/dask-ml/issues/264

I don't think this closes #264. We would want some kind of actual stopping criterion for that.

For now, this provides a convenient way to make multiple passes over the dataset.

I'm not at all sure what the default should be. In https://github.com/dask/dask-ml/pull/258#issuecomment-401954237 @stsievert suggested 5.

Having `max_iter=1` by default makes explaining / understanding `Incremental` easier. "Dask-ML just makes the `partial_fit` calls for you". But I'm not sold on that.