### PR TITLE
Consolidates compat modules

### DIFF
--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -1,14 +1,12 @@
 import contextlib
 
 import packaging.version
-from distutils.version import LooseVersion
 import sklearn
 import dask
 
 
 SK_VERSION = packaging.version.parse(sklearn.__version__)
-_SK_VERSION = LooseVersion(sklearn.__version__)
-_HAS_MULTIPLE_METRICS = _SK_VERSION >= '0.19.0'
+HAS_MULTIPLE_METRICS = SK_VERSION >= packaging.version.parse('0.19.0')
 
 DASK_VERSION = packaging.version.parse(dask.__version__)
 

--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -1,11 +1,15 @@
 import contextlib
 
 import packaging.version
+from distutils.version import LooseVersion
 import sklearn
 import dask
 
 
 SK_VERSION = packaging.version.parse(sklearn.__version__)
+_SK_VERSION = LooseVersion(sklearn.__version__)
+_HAS_MULTIPLE_METRICS = _SK_VERSION >= '0.19.0'
+
 DASK_VERSION = packaging.version.parse(dask.__version__)
 
 

--- a/dask_ml/compat.py
+++ b/dask_ml/compat.py
@@ -1,7 +1,0 @@
-import packaging.version
-import sklearn
-import dask
-
-
-SK_VERSION = packaging.version.parse(sklearn.__version__)
-DASK_VERSION = packaging.version.parse(dask.__version__)

--- a/dask_ml/model_selection/_compat.py
+++ b/dask_ml/model_selection/_compat.py
@@ -1,6 +1,0 @@
-from distutils.version import LooseVersion
-from sklearn import __version__
-
-_SK_VERSION = LooseVersion(__version__)
-
-_HAS_MULTIPLE_METRICS = _SK_VERSION >= '0.19.0'

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -6,6 +6,7 @@ from itertools import repeat
 from multiprocessing import cpu_count
 import numbers
 
+import packaging.version
 import numpy as np
 import dask
 from dask.base import tokenize
@@ -40,7 +41,7 @@ from .methods import (fit, fit_transform, fit_and_score, pipeline, fit_best,
                       decompress_params, score, feature_union,
                       feature_union_concat, MISSING)
 from .utils import to_indexable, to_keys, unzip, is_dask_collection
-from .._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
+from .._compat import HAS_MULTIPLE_METRICS, SK_VERSION
 
 try:
     from cytoolz import get, pluck
@@ -51,7 +52,7 @@ except ImportError:  # pragma: no cover
 __all__ = ['GridSearchCV', 'RandomizedSearchCV']
 
 
-if _SK_VERSION >= '0.19.1':
+if SK_VERSION >= packaging.version.parse('0.19.1'):
     from sklearn.utils.deprecation import DeprecationDict
     _RETURN_TRAIN_SCORE_DEFAULT = 'warn'
 
@@ -741,7 +742,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
     def best_score_(self):
         check_is_fitted(self, 'cv_results_')
         self._check_if_refit('best_score_')
-        if _HAS_MULTIPLE_METRICS and self.multimetric_:
+        if HAS_MULTIPLE_METRICS and self.multimetric_:
             key = self.refit
         else:
             key = 'score'
@@ -823,7 +824,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
             Parameters passed to the ``fit`` method of the estimator
         """
         estimator = self.estimator
-        if _HAS_MULTIPLE_METRICS:
+        if HAS_MULTIPLE_METRICS:
             from sklearn.metrics.scorer import _check_multimetric_scoring
             scorer, multimetric = _check_multimetric_scoring(
                 estimator,
@@ -883,7 +884,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         self.cv_results_ = results
 
         if self.refit:
-            if _HAS_MULTIPLE_METRICS and self.multimetric_:
+            if HAS_MULTIPLE_METRICS and self.multimetric_:
                 key = self.refit
             else:
                 key = 'score'

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -40,7 +40,7 @@ from .methods import (fit, fit_transform, fit_and_score, pipeline, fit_best,
                       decompress_params, score, feature_union,
                       feature_union_concat, MISSING)
 from .utils import to_indexable, to_keys, unzip, is_dask_collection
-from ._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
+from .._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
 
 try:
     from cytoolz import get, pluck

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -46,7 +46,7 @@ from dask_ml.model_selection import compute_n_splits, check_cv
 from dask_ml.model_selection._search import (
     _normalize_n_jobs, _normalize_scheduler
 )
-from dask_ml.model_selection._compat import _HAS_MULTIPLE_METRICS
+from dask_ml._compat import _HAS_MULTIPLE_METRICS
 from dask_ml.model_selection.methods import CVCache
 from dask_ml.model_selection.utils_test import (
     FailingClassifier, MockClassifier,

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -46,7 +46,7 @@ from dask_ml.model_selection import compute_n_splits, check_cv
 from dask_ml.model_selection._search import (
     _normalize_n_jobs, _normalize_scheduler
 )
-from dask_ml._compat import _HAS_MULTIPLE_METRICS
+from dask_ml._compat import HAS_MULTIPLE_METRICS
 from dask_ml.model_selection.methods import CVCache
 from dask_ml.model_selection.utils_test import (
     FailingClassifier, MockClassifier,
@@ -487,7 +487,7 @@ def test_feature_union_fit_failure():
 
 
 @ignore_warnings
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_feature_union_fit_failure_multiple_metrics():
     scoring = {"score_1": _passthrough_scorer, "score_2": _passthrough_scorer}
     X, y = make_classification(n_samples=100, n_features=10, random_state=0)
@@ -667,7 +667,7 @@ def test_scheduler_param_bad():
         _normalize_scheduler('threeding', 4)
 
 
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_cv_multiplemetrics():
     X, y = make_classification(random_state=0)
 
@@ -684,7 +684,7 @@ def test_cv_multiplemetrics():
     assert isinstance(a.best_params_, type(b.best_params_))
 
 
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_cv_multiplemetrics_requires_refit_metric():
     X, y = make_classification(random_state=0)
 
@@ -696,7 +696,7 @@ def test_cv_multiplemetrics_requires_refit_metric():
         a.fit(X, y)
 
 
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_cv_multiplemetrics_no_refit():
     X, y = make_classification(random_state=0)
 

--- a/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
@@ -37,7 +37,7 @@ from dask_ml.model_selection.utils_test import (
     CheckingClassifier, MockDataFrame,
     ignore_warnings
 )
-from dask_ml.model_selection._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
+from dask_ml._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
 
 
 class LinearSVCNoScore(LinearSVC):

--- a/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
@@ -4,6 +4,7 @@
 
 import pickle
 import pytest
+import packaging.version
 
 import dask
 import dask.array as da
@@ -37,7 +38,7 @@ from dask_ml.model_selection.utils_test import (
     CheckingClassifier, MockDataFrame,
     ignore_warnings
 )
-from dask_ml._compat import _HAS_MULTIPLE_METRICS, _SK_VERSION
+from dask_ml._compat import HAS_MULTIPLE_METRICS, SK_VERSION
 
 
 class LinearSVCNoScore(LinearSVC):
@@ -197,7 +198,7 @@ def test_grid_search_groups():
         gs.fit(X, y)
 
 
-@pytest.mark.skipif(_SK_VERSION < '0.19.1',
+@pytest.mark.skipif(SK_VERSION < packaging.version.parse('0.19.1'),
                     reason='only deprecated for >= 0.19.1')
 def test_return_train_score_warn():
     # Test that warnings are raised. Will be removed in sklearn 0.21
@@ -291,7 +292,7 @@ def test_no_refit():
                  'best parameters' % fn_name) in str(exc.value))
 
 
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_no_refit_multiple_metrics():
     clf = DecisionTreeClassifier()
     scoring = {'score_1': 'accuracy', 'score_2': 'accuracy'}
@@ -1034,7 +1035,7 @@ def test_search_train_scores_set_to_false():
         assert not key.endswith('train_score')
 
 
-@pytest.mark.skipif(not _HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
+@pytest.mark.skipif(not HAS_MULTIPLE_METRICS, reason="Added in 0.19.0")
 def test_multiple_metrics():
     scoring = {'AUC': 'roc_auc', 'Accuracy': make_scorer(accuracy_score)}
 


### PR DESCRIPTION
This PR consolidates `dask_ml/_compat.py`, `dask_ml/compat.py`, and the newly added `dask_ml/model_selection/_compat.py` modules into a single `dask_ml/_compat.py` file. 

Closes #242