### PR TITLE
[WIP] Wrap ``sklearn.model_selection`` routines with dask

### DIFF
--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -8,6 +8,7 @@ from ._search import (
     compute_n_splits, check_cv
 )
 from ._split import ShuffleSplit, train_test_split
+from ._validate import cross_validate, cross_val_score, cross_val_predict
 
 
 __all__ = [
@@ -17,4 +18,7 @@ __all__ = [
     'train_test_split',
     'compute_n_splits',
     'check_cv',
+    'cross_validate',
+    'cross_val_score',
+    'cross_val_predict',
 ]

--- a/dask_ml/model_selection/_validate.py
+++ b/dask_ml/model_selection/_validate.py
@@ -1,0 +1,46 @@
+import functools
+
+from sklearn.model_selection import cross_validate as _cross_validate
+from sklearn.model_selection import cross_val_score as _cross_val_score
+from sklearn.model_selection import cross_val_predict as _cross_val_predict
+from dask.base import is_dask_collection
+
+from dask_ml import joblib
+
+
+def _joblibify(f):
+    """
+    Allows execution of functions using joblib('dask') as backend.
+
+    :param f: A function with signature ``f(something, X, y=None, **kwargs)``
+    :return: A function that runs on dask
+    """
+    @functools.wraps(f)
+    def wrap(*args, **kwargs):
+        X = args[1]
+        y = kwargs.get("y")
+
+        if not y and len(args) == 3:
+            y = args[2]
+
+        if not y:  # unsupervised
+            scatter = [X]
+        else:
+            scatter = [X, y]
+
+        if is_dask_collection(X) or is_dask_collection(y):
+            message = ('Dask collections are not supported '
+                       'by {} yet. '.format(f.__name__))
+            message += ('You can explicily compute them (if you data fit '
+                        'in memory) through ``X, y = dask.compute(X, y)``')
+            raise NotImplementedError(message)
+
+        with joblib.parallel_backend("dask", scatter=scatter):
+            return f(*args, **kwargs)
+
+    return wrap
+
+
+cross_validate = _joblibify(_cross_validate)
+cross_val_score = _joblibify(_cross_val_score)
+cross_val_predict = _joblibify(_cross_val_predict)

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -42,6 +42,18 @@ Dask-ML provides drop-in replacements for grid and randomized search.
    model_selection.GridSearchCV
    model_selection.RandomizedSearchCV
 
+Dask-ML provides the following drop-in replacements for cross validation when
+the data fits in memory. When it doesn't fit in memory, the functions can still
+be used by using ``X, y = dask.compute(X, y)``
+
+.. autosummary::
+   :toctree: generated
+   :template: function.rst
+
+   model_selection.cross_validate
+   model_selection.cross_val_score
+   model_selection.cross_val_predict
+
 
 :mod:`dask_ml.linear_model`: Generalized Linear Models
 ======================================================


### PR DESCRIPTION
The commit adds ``cross_validate, cross_val_score``, and
``cross_val_predict`` methods that wrap the sklearn equivalent methods
by using ``joblib`` with dask as a backend.

It should close #251

@TomAugspurger I've marked it as WIP to see if this is the direction you would like the PR to go in order to close the issue. Let me know otherwise.