### PR TITLE
MAINT: remove tokenize in partial_fit

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -105,11 +105,13 @@ class _BigPartialFitMixin(object):
 def _partial_fit(model, x, y, kwargs=None):
     kwargs = kwargs or dict()
     start = tic()
-    logger.info("Starting partial-fit %s", dask.base.tokenize(model, x, y))
+    if logger.getEffectiveLevel() == logging.DEBUG:
+        token = dask.base.tokenize(model, x, y)
+        logger.debug("Starting partial-fit %s", token)
     model.partial_fit(x, y, **kwargs)
     stop = tic()
-    logger.info("Finished partial-fit %s [%0.2f]",
-                dask.base.tokenize(model, x, y), stop - start)
+    if logger.getEffectiveLevel() == 'debug':
+        logger.debug("Finished partial-fit %s [%0.2f]", token, stop - start)
     return model
 
 

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -4,7 +4,6 @@ import logging
 import os
 import warnings
 from abc import ABCMeta
-from timeit import default_timer as tic
 
 import numpy as np
 import six

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -104,14 +104,7 @@ class _BigPartialFitMixin(object):
 
 def _partial_fit(model, x, y, kwargs=None):
     kwargs = kwargs or dict()
-    start = tic()
-    if logger.getEffectiveLevel() == logging.DEBUG:
-        token = dask.base.tokenize(model, x, y)
-        logger.debug("Starting partial-fit %s", token)
     model.partial_fit(x, y, **kwargs)
-    stop = tic()
-    if logger.getEffectiveLevel() == 'debug':
-        logger.debug("Finished partial-fit %s [%0.2f]", token, stop - start)
     return model
 
 


### PR DESCRIPTION
Closes #261 

With this I've seen a speedup of about 2x for my example notebook in https://github.com/dask/dask-examples/pull/15, which is supported by the dask dashboard profiling graph.