### PR TITLE
MAINT: randomly sample chunks for partial_fit calls

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -121,8 +121,8 @@ def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None,
     Model must support the ``partial_fit`` interface for online or batch
     learning.
 
-    This method will be called on dask arrays in sequential order.  Ideally
-    your rows are independent and identically distributed.
+    Ideally your rows are independent and identically distributed. By default,
+    this function will step through chunks of the arrays in random order.
 
     Parameters
     ----------

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -13,7 +13,6 @@ import sklearn.utils
 
 import dask
 from dask.delayed import Delayed
-import dask.array as da
 
 from ._utils import copy_learned_attributes
 

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -5,6 +5,7 @@ import os
 import warnings
 from abc import ABCMeta
 from timeit import default_timer as tic
+import random
 
 import numpy as np
 import six
@@ -171,11 +172,13 @@ def fit(model, x, y, compute=True, **kwargs):
         x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
 
     nblocks = len(x.chunks[0])
+    order = list(range(nblocks))
+    random.shuffle(order)
 
-    name = 'fit-' + dask.base.tokenize(model, x, y, kwargs)
+    name = 'fit-' + dask.base.tokenize(model, x, y, kwargs, order)
     dsk = {(name, -1): model}
     dsk.update({(name, i): (_partial_fit, (name, i - 1),
-                                          (x.name, i, 0),
+                                          (x.name, order[i], 0),
                                           (getattr(y, 'name', ''), i), kwargs)
                 for i in range(nblocks)})
 

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -179,7 +179,8 @@ def fit(model, x, y, compute=True, **kwargs):
     dsk = {(name, -1): model}
     dsk.update({(name, i): (_partial_fit, (name, i - 1),
                                           (x.name, order[i], 0),
-                                          (getattr(y, 'name', ''), i), kwargs)
+                                          (getattr(y, 'name', ''), order[i]),
+                            kwargs)
                 for i in range(nblocks)})
 
     new_dsk = dask.sharedict.merge((name, dsk), x.dask, getattr(y, 'dask', {}))

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -323,11 +323,13 @@ class Incremental(ParallelPostFit):
            a single NumPy array, which may exhaust the memory of your worker.
            You probably want to always specify `scoring`.
 
-    random_state : int or numpy.random.RandomState
+    random_state : int or numpy.random.RandomState, optional
         Random object that determines how to shuffle blocks.
 
-    shuffle_blocks : bool
-        Whether to randomly shuffle the blocks or now
+    shuffle_blocks : bool, default True
+        Determines whether to call ``partial_fit`` on a randomly selected chunk
+        of the Dask arrays (default), or to fit in sequential order. This does
+        not control shuffle between blocks or shuffling each block.
 
     Attributes
     ----------

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -9,7 +9,6 @@ from sklearn.linear_model import SGDClassifier
 import numpy.linalg as LA
 
 from dask_ml.wrappers import Incremental
-from dask_ml.utils import assert_estimator_equal
 import dask_ml.metrics
 from dask_ml.metrics.scorer import check_scoring
 
@@ -38,7 +37,7 @@ def test_incremental_basic(scheduler):
     rng = da.random.RandomState(42)
     X = rng.normal(size=(n, d), chunks=30)
     coef_star = rng.uniform(size=d, chunks=d)
-    y = da.sign(X @ coef_star)
+    y = da.sign(X.dot(coef_star))
     y = (y + 1) / 2
 
     with scheduler() as (s, [_, _]):

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -6,7 +6,6 @@ import sklearn.datasets
 from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
-import numpy.linalg as LA
 
 from dask_ml.wrappers import Incremental
 import dask_ml.metrics
@@ -52,7 +51,8 @@ def test_incremental_basic(scheduler):
         assert result is clf
 
         assert isinstance(result.estimator_.coef_, np.ndarray)
-        rel_error = LA.norm(clf.coef_ - est2.coef_) / LA.norm(clf.coef_)
+        rel_error = np.linalg.norm(clf.coef_ - est2.coef_)
+        rel_error /= np.linalg.norm(clf.coef_)
         assert rel_error < 0.9
 
         assert set(dir(clf.estimator_)) == set(dir(est2))

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -61,7 +61,8 @@ def test_incremental_basic(scheduler):
         result = clf.predict(X)
         expected = est2.predict(X)
         assert isinstance(result, da.Array)
-        rel_error = LA.norm(result - expected) / LA.norm(expected)
+        rel_error = np.linalg.norm(result - expected)
+        rel_error /= np.linalg.norm(expected)
         assert rel_error < 0.2
 
         # score

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -54,18 +54,25 @@ def test_fit_rechunking():
 
 
 def test_fit_shuffle_blocks():
+    N = 10
+    X = da.from_array(1 + np.arange(N).reshape(-1, 1), chunks=1)
+    y = da.from_array(np.ones(N), chunks=1)
+    classes = [0, 1]
+
+    sgd = SGDClassifier(max_iter=5, random_state=0, fit_intercept=False,
+                        shuffle=False)
+
+    sgd1 = fit(clone(sgd), X, y, random_state=0, classes=classes)
+    sgd2 = fit(clone(sgd), X, y, random_state=42, classes=classes)
+    assert len(sgd1.coef_) == len(sgd2.coef_) == 1
+    assert not np.allclose(sgd1.coef_, sgd2.coef_)
+
     X, y = make_classification(random_state=0, chunks=20)
-    sgd = SGDClassifier(max_iter=5)
-
-    fit(clone(sgd), X, y, classes=np.array([-1, 0, 1]),
-        shuffle_blocks=False)
-    fit(clone(sgd), X, y, classes=np.array([-1, 0, 1]),
-        shuffle_blocks=True)
-
-    fit(clone(sgd), X, y, classes=np.array([-1, 0, 1]),
-        shuffle_blocks=True, random_state=42)
-    fit(clone(sgd), X, y, classes=np.array([-1, 0, 1]),
-        shuffle_blocks=True, random_state=np.random.RandomState(42))
+    sgd_a = fit(clone(sgd), X, y, random_state=0, classes=classes,
+                shuffle_blocks=False)
+    sgd_b = fit(clone(sgd), X, y, random_state=42, classes=classes,
+                shuffle_blocks=False)
+    assert np.allclose(sgd_a.coef_, sgd_b.coef_)
 
     with pytest.raises(ValueError, match='cannot be used to seed'):
         fit(sgd, X, y, classes=np.array([-1, 0, 1]),


### PR DESCRIPTION
Closes #274.

A screenshot of different `partial_fit` calls:

| Before (almost) | After |
|:--:|:--:|
|<img width="609" alt="screen shot 2018-07-03 at 11 06 04 am" src="https://user-images.githubusercontent.com/1320475/42329630-ac187c3a-8060-11e8-84c5-cc7aaad365be.png"> | <img width="624" alt="screen shot 2018-07-03 at 1 07 36 pm" src="https://user-images.githubusercontent.com/1320475/42237033-2bddf11e-7eec-11e8-88c5-5f0ebd2fb4df.png"> |

I only show the before for some comparison, though it's not exact (and was in the debug process). It is "almost" because it uses a fixed seed every time, not a random seed. It does not run through the blocks in sequential order as mentioned in the previous docs.