### PR TITLE
Avoid calling compute prior to assert_eq in tests

### DIFF
--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -188,6 +188,31 @@ class RobustScaler(skdata.RobustScaler):
             X /= self.scale_
         return X
 
+    def inverse_transform(self, X):
+        """Scale back the data to the original representation
+
+        Parameters
+        ----------
+        X : array-like
+            The data used to scale along the specified axis.
+
+        This implementation was copied and modified from Scikit-Learn.
+
+        See License information here:
+        https://github.com/scikit-learn/scikit-learn/blob/master/README.rst
+        """
+        check_is_fitted(self, 'center_', 'scale_')
+
+        # if sparse.issparse(X):
+        #     if self.with_scaling:
+        #         inplace_column_scale(X, self.scale_)
+        # else:
+        if self.with_scaling:
+            X *= self.scale_
+        if self.with_centering:
+            X += self.center_
+        return X
+
 
 class QuantileTransformer(skdata.QuantileTransformer):
     """Transforms features using quantile information.

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -156,6 +156,38 @@ class RobustScaler(skdata.RobustScaler):
         self.scale_ = skdata._handle_zeros_in_scale(self.scale_, copy=False)
         return self
 
+    def transform(self, X):
+        """Center and scale the data.
+
+        Can be called on sparse input, provided that ``RobustScaler`` has been
+        fitted to dense input and ``with_centering=False``.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix}
+            The data used to scale along the specified axis.
+
+        This implementation was copied and modified from Scikit-Learn.
+
+        See License information here:
+        https://github.com/scikit-learn/scikit-learn/blob/master/README.rst
+        """
+        if self.with_centering:
+            check_is_fitted(self, 'center_')
+        if self.with_scaling:
+            check_is_fitted(self, 'scale_')
+        X = self._check_array(X, self.copy)
+
+        # if sparse.issparse(X):
+        #     if self.with_scaling:
+        #         inplace_column_scale(X, 1.0 / self.scale_)
+        # else:
+        if self.with_centering:
+            X -= self.center_
+        if self.with_scaling:
+            X /= self.scale_
+        return X
+
 
 class QuantileTransformer(skdata.QuantileTransformer):
     """Transforms features using quantile information.

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -82,8 +82,7 @@ class TestStandardScaler(object):
 
     def test_inverse_transform(self):
         a = dpp.StandardScaler()
-        assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
-                     X.compute())
+        assert_eq_ar(a.inverse_transform(a.fit_transform(X)), X)
 
 
 class TestMinMaxScaler(object):
@@ -97,15 +96,13 @@ class TestMinMaxScaler(object):
 
     def test_inverse_transform(self):
         a = dpp.MinMaxScaler()
-        assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
-                     X.compute())
+        assert_eq_ar(a.inverse_transform(a.fit_transform(X)), X)
 
     @pytest.mark.xfail(reason="removed columns")
     def test_df_inverse_transform(self):
         mask = ["3", "4"]
         a = dpp.MinMaxScaler(columns=mask)
-        assert_eq_df(a.inverse_transform(a.fit_transform(df2)).compute(),
-                     df2.compute())
+        assert_eq_df(a.inverse_transform(a.fit_transform(df2)), df2)
 
     def test_df_values(self):
         est1 = dpp.MinMaxScaler()
@@ -137,7 +134,7 @@ class TestMinMaxScaler(object):
         assert isinstance(dfa, pd.DataFrame)
         assert_eq_ar(dfa[mask].values, mxb[:, mask_ix])
         assert_eq_df(dfa.drop(mask, axis=1),
-                     df2.drop(mask, axis=1).compute())
+                     df2.drop(mask, axis=1))
 
 
 class TestRobustScaler(object):
@@ -166,12 +163,11 @@ class TestRobustScaler(object):
         a.scale_ = b.scale_
         a.center_ = b.center_
 
-        assert_eq_ar(a.transform(X).compute(), b.transform(X.compute()))
+        assert_eq_ar(a.transform(X), b.transform(X.compute()))
 
     def test_inverse_transform(self):
         a = dpp.RobustScaler()
-        assert_eq_ar(a.inverse_transform(a.fit_transform(X)).compute(),
-                     X.compute())
+        assert_eq_ar(a.inverse_transform(a.fit_transform(X)), X)
 
     def test_df_values(self):
         est1 = dpp.RobustScaler()
@@ -417,7 +413,6 @@ class TestOrdinalEncoder:
                             npartitions=2)
         enc.fit(df)
         assert_eq_df(df, enc.inverse_transform(enc.transform(df)))
-        assert_eq_df(df, enc.inverse_transform(enc.transform(df).compute()))
+        assert_eq_df(df, enc.inverse_transform(enc.transform(df)))
         assert_eq_df(df, enc.inverse_transform(enc.transform(df).values))
-        assert_eq_df(df, enc.inverse_transform(
-            enc.transform(df).values.compute()))
+        assert_eq_df(df, enc.inverse_transform(enc.transform(df).values))

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -119,7 +119,9 @@ class TestMinMaxScaler(object):
         assert_eq_ar(est1.transform(df).values, est2.transform(X))
         assert_eq_ar(est1.transform(X), est2.transform(df).values)
 
-        assert_eq_ar(result_ar, result_df.values)
+        if hasattr(result_df, 'values'):
+            result_df = result_df.values
+        assert_eq_ar(result_ar, result_df)
 
     @pytest.mark.xfail(reason="removed columns")
     def test_df_column_slice(self):


### PR DESCRIPTION
This changes some tests so that assert_eq accepts dask objects rather
than numpy ones.  This allows us to perform a variety of useful checks
like `x.dtype == x.compute().dtype`.