### PR TITLE
WIP: ENH: provide utilility to shuffle datasets

### DIFF
--- a/dask_ml/datasets.py
+++ b/dask_ml/datasets.py
@@ -2,6 +2,7 @@ import numbers
 
 import dask
 import dask.array as da
+import dask.dataframe as dd
 import numpy as np
 import sklearn.datasets
 import sklearn.utils

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -13,6 +13,7 @@ import sklearn.utils.validation as sk_validation
 from dask import delayed
 from dask.array.utils import assert_eq as assert_eq_ar
 from dask.dataframe.utils import assert_eq as assert_eq_df
+import sklearn.utils
 
 
 def svd_flip(u, v):
@@ -241,7 +242,27 @@ def _format_bytes(n):
     return '%d B' % n
 
 
+def shuffle(X, y, random_state=None, compute=False):
+    assert len(X) == len(y), "Arrays must be same size"
+
+    rng = sklearn.utils.check_random_state(random_state)
+    i = da.from_array(rng.permutation(len(y)), chunks=y.chunks)
+
+    X_df = dd.from_dask_array(X)
+    X_df = X_df.set_index(dd.from_dask_array(i))
+
+    rng = sklearn.utils.check_random_state(random_state)
+    i = da.from_array(rng.permutation(len(y)), chunks=y.chunks)
+
+    y = y.reshape(-1, 1)
+    y_df = dd.from_dask_array(y)
+    y_df = y_df.set_index(dd.from_dask_array(i))
+
+    return X_df.values, y_df.values
+
+
 __all__ = ['assert_estimator_equal',
            'check_array',
            'check_random_state',
-           'check_chunks']
+           'check_chunks',
+           'shuffle']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,21 @@ Foo = namedtuple('Foo', 'a_ b_ c_ d_')
 Bar = namedtuple("Bar", 'a_ b_ d_ e_')
 
 
+def test_shuffle():
+    X = np.arange(9*9).reshape(9, 9) // 9
+    X = da.from_array(X, chunks=(1, 9))
+    y = da.arange(9, chunks=1)
+    X2, y2 = dask_ml.datasets.shuffle(X, y, random_state=42)
+
+    assert X2.shape == X.shape
+    assert X2.chunks == X.chunks
+    assert y2.shape == y.shape
+    assert y2.chunks == y.chunks
+    X2 = X2.compute()
+    y2 = y2.compute()
+    assert np.allclose(X2.mean(axis=1), y2)
+
+
 def test_slice_columns():
     columns = [2, 3]
     df2 = slice_columns(df, columns)


### PR DESCRIPTION
This is a utility to shuffle datasets, motivated by https://github.com/dask/dask-examples/pull/15#discussion_r200430157.

I would imagine this would be useful with `Incremental`.

This involves https://github.com/dask/dask/issues/3090. I tried to implement it with https://github.com/dask/dask/issues/3090#issuecomment-373948380 but kept running into issues.