### PR TITLE
Adds packaging requirement to setup.py

### DIFF
--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -9,4 +9,4 @@ conda env create -f ci/environment-${PYTHON}.yml --name=${ENV_NAME}
 conda env list
 source activate ${ENV_NAME}
 pip install --no-deps --quiet -e .
-conda list ${ENV_NAME}
+conda list -n ${ENV_NAME}

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 install_requires = ['dask', 'numpy', 'pandas', 'scikit-learn',
                     'scipy', 'dask-glm', 'six',
-                    'multipledispatch>=0.4.9']
+                    'multipledispatch>=0.4.9', 'packaging']
 
 # Optional Requirements
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme', 'nbsphinx',


### PR DESCRIPTION
This PR adds `packaging` to `install_requires` in `setup.py`. Closes #290.