### PR TITLE
DOC: link to dask-examples on examples page

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -5,8 +5,6 @@ Examples
 ========
 
 This is a set of runnable examples demonstrating how to *use* Dask-ML.
-We also have a set of examples benchmarking the performance of Dask-ML
-on larger datasets in the `dask-ml-benchmarks`_ repository
 
 .. toctree::
    :maxdepth: 2
@@ -19,4 +17,11 @@ on larger datasets in the `dask-ml-benchmarks`_ repository
    examples/xgboost
    examples/tensorflow
 
+We also have sets of
+
+* examples in the `dask-examples`_ repository, which has machine learning
+  examples that can be launched online with Binder.
+* Dask-ML performance benchmarks in the `dask-ml-benchmarks`_ repository
+
+.. _dask-examples: https://www.github.com/dask/dask-examples
 .. _dask-ml-benchmarks: https://dask-ml-benchmarks.readthedocs.io


### PR DESCRIPTION
And a little reformatting to make the links more clear.