### PR TITLE
Add `toolz` as a dependency for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
 install_requires = [
-    "dask",
+    "dask[array]",
     "numpy",
     "pandas",
     "scikit-learn",
@@ -21,7 +21,6 @@ install_requires = [
     "six",
     "multipledispatch>=0.4.9",
     "packaging",
-    "toolz",
 ]
 
 # Optional Requirements

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     "six",
     "multipledispatch>=0.4.9",
     "packaging",
+    "toolz",
 ]
 
 # Optional Requirements


### PR DESCRIPTION
`toolz` was missing as a dependency in the `setup.py` `install_requires`
list.

fixes issue #304 