### PR TITLE
ENH: LabelEncoder supports pandas Categorical

### DIFF
--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -4,6 +4,7 @@ from operator import getitem
 
 import dask.array as da
 import dask.dataframe as dd
+import pandas as pd
 import numpy as np
 
 from sklearn.preprocessing import label as sklabel
@@ -11,12 +12,100 @@ from sklearn.utils.validation import check_is_fitted
 
 
 class LabelEncoder(sklabel.LabelEncoder):
+    """Encode labels with value between 0 and n_classes-1.
 
-    __doc__ = sklabel.LabelEncoder.__doc__
+    .. note::
+
+       This differs from the scikit-learn version for Categorical data.
+       When passed a categorical `y`, this implementation will use the
+       categorical information for the label encoding and transformation.
+       You will receive different answers when
+
+       1. Your categories are not monotonically increasing
+       2. You have unobserved categories
+
+       Specify ``use_categorical=False`` to recover the scikit-learn behavior.
+
+    Parameters
+    ----------
+    use_categorical : bool, default True
+        Whether to use the categorical dtype information when `y` is a
+        dask or pandas Series with a categorical dtype.
+
+    Attributes
+    ----------
+    classes_ : array of shape (n_class,)
+        Holds the label for each class.
+    dtype_ : Optional CategoricalDtype
+        For Categorical `y`, the dtype is stored here.
+
+    Examples
+    --------
+    `LabelEncoder` can be used to normalize labels.
+
+    >>> from dask_ml import preprocessing
+    >>> le = preprocessing.LabelEncoder()
+    >>> le.fit([1, 2, 2, 6])
+    LabelEncoder()
+    >>> le.classes_
+    array([1, 2, 6])
+    >>> le.transform([1, 1, 2, 6]) #doctest: +ELLIPSIS
+    array([0, 0, 1, 2]...)
+    >>> le.inverse_transform([0, 0, 1, 2])
+    array([1, 1, 2, 6])
+
+    It can also be used to transform non-numerical labels (as long as they are
+    hashable and comparable) to numerical labels.
+
+    >>> le = preprocessing.LabelEncoder()
+    >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
+    LabelEncoder()
+    >>> list(le.classes_)
+    ['amsterdam', 'paris', 'tokyo']
+    >>> le.transform(["tokyo", "tokyo", "paris"]) #doctest: +ELLIPSIS
+    array([2, 2, 1]...)
+    >>> list(le.inverse_transform([2, 2, 1]))
+    ['tokyo', 'tokyo', 'paris']
+
+    When using Dask, we strongly recommend using a Categorical dask Series if
+    possible. This avoids a (potentially expensive) scan of the values and
+    enables a faster `transform` algorithm.
+
+    >>> import dask.dataframe as dd
+    >>> import pandas as pd
+    >>> data = dd.from_pandas(pd.Series(['a', 'a', 'b'], dtype='category'),
+    ...                       npartitions=2)
+    >>> le.fit_transform(data)
+    dask.array<values, shape=(nan,), dtype=int8, chunksize=(nan,)>
+    >>> le.fit_transform(data).compute()
+    array([0, 0, 1], dtype=int8)
+    """
+
+    def __init__(self, use_categorical=True):
+        self.use_categorical = use_categorical
+        super(LabelEncoder, self).__init__()
 
     def _check_array(self, y):
+        if isinstance(y, (dd.Series, pd.DataFrame)):
+            y = y.squeeze()
+
+            if y.ndim > 1:
+                raise ValueError("Expected a 1-D array or Series.")
+
+        if not self.use_categorical:
+            if isinstance(y, dd.Series):
+                y = da.asarray(y)
+            elif isinstance(y, pd.Series):
+                y = np.asarray(y)
+
         if isinstance(y, dd.Series):
-            y = da.asarray(y)
+            if pd.api.types.is_categorical_dtype(y):
+                # TODO(dask-3784): just call y.cat.as_known()
+                # https://github.com/dask/dask/issues/3784
+                if not y.cat.known:
+                    y = y.cat.as_known()
+            else:
+                y = da.asarray(y)
         return y
 
     def fit(self, y):
@@ -25,10 +114,17 @@ class LabelEncoder(sklabel.LabelEncoder):
         if isinstance(y, da.Array):
             classes_ = da.unique(y)
             classes_ = classes_.compute()
+            dtype = None
+        elif _is_categorical(y):
+            # This may not be sorted.
+            classes_ = np.array(y.cat.categories)
+            dtype = y.dtype
         else:
             classes_ = np.unique(y)
+            dtype = None
 
         self.classes_ = classes_
+        self.dtype_ = dtype
 
         return self
 
@@ -43,6 +139,9 @@ class LabelEncoder(sklabel.LabelEncoder):
             return da.map_blocks(
                 np.searchsorted, self.classes_, y, dtype=self.classes_.dtype
             )
+        elif isinstance(y, (pd.Series, dd.Series)):
+            assert y.dtype.categories.equals(self.dtype_.categories)
+            return y.cat.codes.values
         else:
             return np.searchsorted(self.classes_, y)
 
@@ -51,7 +150,36 @@ class LabelEncoder(sklabel.LabelEncoder):
         y = self._check_array(y)
 
         if isinstance(y, da.Array):
-            return da.map_blocks(getitem, self.classes_, y, dtype=self.classes_.dtype)
+            if getattr(self, "dtype_", None):
+                # -> Series[category]
+                result = (
+                    dd.from_dask_array(y)
+                    .astype("category")
+                    .cat.set_categories(np.arange(len(self.classes_)))
+                    .cat.rename_categories(self.dtype_.categories)
+                )
+                if self.dtype_.ordered:
+                    result = result.cat.as_ordered()
+                return result
+            else:
+                return da.map_blocks(
+                    getitem, self.classes_, y, dtype=self.classes_.dtype
+                )
         else:
             y = np.asarray(y)
-            return self.classes_[y]
+            if getattr(self, "dtype_", None):
+                return pd.Series(
+                    pd.Categorical.from_codes(
+                        y,
+                        categories=self.dtype_.categories,
+                        ordered=self.dtype_.ordered,
+                    )
+                )
+            else:
+                return self.classes_[y]
+
+
+def _is_categorical(y):
+    return isinstance(y, (dd.Series, pd.Series)) and pd.api.types.is_categorical_dtype(
+        y
+    )

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -197,20 +197,13 @@ def _encode_categorical(values, encode=False):
         return uniques
 
 
-def _encode_dask_array(values, uniques=None, encode=False):
-    # type: (da.Array, bool, bool) -> Any
-    if uniques is None:
-        if encode:
-            uniques, encoded = da.unique(values, return_inverse=True)
-            return uniques, encoded
-        else:
-            return da.unique(values)
+def _encode_dask_array(values, encode=False):
+    # type: (da.Array, bool) -> Any
     if encode:
-        # TODO: validate new labels in `values`
-        encoded = da.map_blocks(np.searchsorted, uniques, values, dtype=np.intp)
+        uniques, encoded = da.unique(values, return_inverse=True)
         return uniques, encoded
     else:
-        return uniques
+        return da.unique(values)
 
 
 def _is_categorical(y):

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -4,8 +4,8 @@ from operator import getitem
 
 import dask.array as da
 import dask.dataframe as dd
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from sklearn.preprocessing import label as sklabel
 from sklearn.utils.validation import check_is_fitted

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -112,24 +112,31 @@ class LabelEncoder(sklabel.LabelEncoder):
         y = self._check_array(y)
 
         if isinstance(y, da.Array):
-            classes_ = da.unique(y)
-            classes_ = classes_.compute()
-            dtype = None
+            classes_ = _encode_dask_array(y)
+            self.classes_ = classes_.compute()
+            self.dtype_ = None
         elif _is_categorical(y):
-            # This may not be sorted.
-            classes_ = np.array(y.cat.categories)
-            dtype = y.dtype
+            self.classes_ = _encode_categorical(y)
+            self.dtype_ = y.dtype
         else:
-            classes_ = np.unique(y)
-            dtype = None
-
-        self.classes_ = classes_
-        self.dtype_ = dtype
+            self.dtype_ = None
+            return super(LabelEncoder, self).fit(y)
 
         return self
 
     def fit_transform(self, y):
-        return self.fit(y).transform(y)
+        y = self._check_array(y)
+
+        if isinstance(y, da.Array):
+            self.classes_, y = _encode_dask_array(y, encode=True)
+            self.dtype_ = None
+        elif _is_categorical(y):
+            self.classes_, y = _encode_categorical(y, encode=True)
+            self.dtype_ = y.dtype
+        else:
+            return super(LabelEncoder, self).fit_transform(y)
+
+        return y
 
     def transform(self, y):
         check_is_fitted(self, "classes_")
@@ -161,7 +168,11 @@ class LabelEncoder(sklabel.LabelEncoder):
                 return result
             else:
                 return da.map_blocks(
-                    getitem, self.classes_, y, dtype=self.classes_.dtype
+                    getitem,
+                    self.classes_,
+                    y,
+                    dtype=self.classes_.dtype,
+                    chunks=y.chunks,
                 )
         else:
             y = np.asarray(y)
@@ -175,6 +186,31 @@ class LabelEncoder(sklabel.LabelEncoder):
                 )
             else:
                 return self.classes_[y]
+
+
+def _encode_categorical(values, encode=False):
+    # type: (Union[dd.Series['category'], pd.Series['category']], bool) -> Any
+    uniques = np.asarray(values.cat.categories)
+    if encode:
+        return uniques, values.cat.codes
+    else:
+        return uniques
+
+
+def _encode_dask_array(values, uniques=None, encode=False):
+    # type: (da.Array, bool, bool) -> Any
+    if uniques is None:
+        if encode:
+            uniques, encoded = da.unique(values, return_inverse=True)
+            return uniques, encoded
+        else:
+            return da.unique(values)
+    if encode:
+        # TODO: validate new labels in `values`
+        encoded = da.map_blocks(np.searchsorted, uniques, values, dtype=np.intp)
+        return uniques, encoded
+    else:
+        return uniques
 
 
 def _is_categorical(y):

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -62,24 +62,6 @@ And then
 If you have any trouble with the build step, please open an issue in the
 `dask-ml issue tracker <https://github.com/dask/dask-ml/issues>`_.
 
-Running tests
-~~~~~~~~~~~~~
-
-Dask-ml uses `py.test <https://docs.pytest.org/en/latest/>`_ for testing. You
-can run tests from the main dask-ml directory as follows:
-
-.. code-block:: none
-
-    py.test tests
-
-Alternatively you may choose to run only a subset of the full test suite. For
-example to test only the preprocessing submodule we would run tests as follows:
-
-.. code-block:: none
-
-    py.test tests/preprocessing
-
-
 Style
 ~~~~~
 
@@ -98,6 +80,35 @@ You may wish to setup a
 `pre-commit hook <https://black.readthedocs.io/en/stable/version_control_integration.html>`_
 to run black when you commit changes.
 
+Running tests
+~~~~~~~~~~~~~
+
+Dask-ml uses `py.test <https://docs.pytest.org/en/latest/>`_ for testing. You
+can run tests from the main dask-ml directory as follows:
+
+.. code-block:: none
+
+    pytest tests
+
+Alternatively you may choose to run only a subset of the full test suite. For
+example to test only the preprocessing submodule we would run tests as follows:
+
+.. code-block:: none
+
+    pytest tests/preprocessing
+
+Coverage
+~~~~~~~~
+
+If your Pull Request decreases the lines of code covered, the CI may fail.
+Sometimes this is OK, and a maintainer will merge it anyway. To check the coverage locally,
+use
+
+.. code-block:: none
+
+   pytest --cov --cov-report=html
+
+You can still use all the usual pytest command-line options in addition to those.
 
 Conventions
 ~~~~~~~~~~~

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -32,6 +32,13 @@ These can be used just like the scikit-learn versions, except that:
 See :mod:`sklearn.preprocessing` for more information about any particular
 transformer.
 
+.. note::
+
+   :class:`dask_ml.preprocessing.LabelEncoder` will use the categorical dtype
+   information for a dask or pandas Series with a :class:`pandas.api.types.CategoricalDtype`.
+   This improves performance, but may lead to different encodings depending on the
+   categories. See the class docstring for more.
+
 Additional Tranformers
 ----------------------
 

--- a/tests/preprocessing/test_label.py
+++ b/tests/preprocessing/test_label.py
@@ -33,19 +33,27 @@ class TestLabelEncoder(object):
 
         a.fit(y)
         b.fit(y.compute())
-        assert_estimator_equal(a, b)
+        exclude = {"dtype_"}
+        assert_estimator_equal(a, b, exclude=exclude)
 
     def test_input_types(self, dask_array, pandas_series):
         a = dpp.LabelEncoder()
         b = spp.LabelEncoder()
 
-        assert_estimator_equal(a.fit(dask_array), b.fit(pandas_series))
+        exclude = {"dtype_"}
+        assert_estimator_equal(a.fit(dask_array), b.fit(pandas_series), exclude=exclude)
 
-        assert_estimator_equal(a.fit(pandas_series), b.fit(pandas_series))
+        assert_estimator_equal(
+            a.fit(pandas_series), b.fit(pandas_series), exclude=exclude
+        )
 
-        assert_estimator_equal(a.fit(pandas_series.values), b.fit(pandas_series))
+        assert_estimator_equal(
+            a.fit(pandas_series.values), b.fit(pandas_series), exclude=exclude
+        )
 
-        assert_estimator_equal(a.fit(dask_array), b.fit(pandas_series.values))
+        assert_estimator_equal(
+            a.fit(dask_array), b.fit(pandas_series.values), exclude=exclude
+        )
 
     @pytest.mark.parametrize("array", [y, s])
     def test_transform(self, array):
@@ -62,3 +70,57 @@ class TestLabelEncoder(object):
 
         a = dpp.LabelEncoder()
         assert_eq_ar(a.inverse_transform(a.fit_transform(array)), da.asarray(array))
+
+    @pytest.mark.parametrize(
+        "categories, transformed",
+        [
+            (["a", "b", "c"], np.array([0, 1, 0], dtype=np.int8)),
+            (["a", "b"], np.array([0, 1, 0], dtype=np.int8)),
+            (["b", "a"], np.array([1, 0, 1], dtype=np.int8)),
+        ],
+    )
+    @pytest.mark.parametrize("daskify", [True, False, "unknown"])
+    @pytest.mark.parametrize("ordered", [True, False])
+    def test_categorical(self, categories, transformed, daskify, ordered):
+        cat = pd.Series(
+            ["a", "b", "a"],
+            dtype=pd.api.types.CategoricalDtype(categories=categories, ordered=ordered),
+        )
+        if daskify:
+            cat = dd.from_pandas(cat, npartitions=2)
+            transformed = da.from_array(transformed, chunks=(2, 1))
+            if daskify == "unknown":
+                cat = cat.cat.as_unknown()
+
+        a = dpp.LabelEncoder().fit(cat)
+
+        if daskify != "unknown":
+            assert a.dtype_ == cat.dtype
+        np.testing.assert_array_equal(a.classes_, categories)
+        result = a.transform(cat)
+        da.utils.assert_eq(result, transformed)
+
+        inv_transformed = a.inverse_transform(result)
+        if daskify:
+            # manually set the divisions for the test
+            inv_transformed.divisions = (0, 2)
+        dd.utils.assert_eq(inv_transformed, cat)
+
+    def test_dataframe_raises(self):
+        df = pd.DataFrame({"A": ["a", "a", "b"]}, dtype="category")
+        dpp.LabelEncoder().fit(df)  # OK
+
+        df["other"] = ["a", "b", "c"]
+        with pytest.raises(ValueError):
+            dpp.LabelEncoder().fit(df)
+
+    def test_use_categorical(self):
+        data = pd.Series(
+            ["b", "c"], dtype=pd.api.types.CategoricalDtype(["c", "a", "b"])
+        )
+        a = dpp.LabelEncoder(use_categorical=False).fit(data)
+        b = spp.LabelEncoder().fit(data)
+        assert_estimator_equal(a, b, exclude={"dtype_"})
+        assert a.dtype_ is None
+
+        da.utils.assert_eq(a.transform(data), b.transform(data))


### PR DESCRIPTION
Enhances LabelEncoder to use CategoricalDtype for pandas and dask
series.

This improves the performance, and will be helpful for implementing OneHotEncoder efficiently for dask dataframes.

```python
import string
import numpy as np
import pandas as pd
import dask.dataframe as dd
import dask_ml.preprocessing

dtype = pd.api.types.CategoricalDtype(list(string.ascii_letters[:12]))
n = 1_000_000

data = dd.from_pandas(
    pd.Series(np.random.choice(dtype.categories, size=n), dtype=dtype),
    npartitions=n // 100_000
)
```

Setup

```python
le = dask_ml.preprocessing.LabelEncoder()  # True / False
codes = le.fit_transform(data)

print('fit')
%timeit le.fit(data)
print('transform')
%timeit le.transform(data)

print('transform-compute')
%timeit le.transform(data).compute()

print('inverse_transform')
%timeit le.inverse_transform(codes)

print('inverse_transform-compute')
%timeit le.inverse_transform(codes).compute()
```

Results

method                    | categorical | no categorical
------                    | ----------- | --------------
fit                       | 43.5 µs     | 625 ms
transform                 | 678 µs      | 33.1 ms
transform-compute         | 4.98 ms     | 128 ms
inverse_transform         | 3.66 ms     | 240 µs
inverse_transform-compute | 37 ms       | 160 ms

cc @jrbourbeau 