### PR TITLE
Don't pack every list-like fit param

### DIFF
--- a/dask_ml/model_selection/methods.py
+++ b/dask_ml/model_selection/methods.py
@@ -16,7 +16,7 @@ from sklearn.utils import safe_indexing
 from sklearn.utils.validation import _is_arraylike, check_consistent_length
 from toolz import pluck
 
-from .utils import copy_estimator
+from .utils import _should_pack_fit_param, copy_estimator
 
 # Copied from scikit-learn/sklearn/utils/fixes.py, can be removed once we drop
 # support for scikit-learn < 0.18.1 or numpy < 1.12.0.
@@ -108,7 +108,11 @@ class CVCache(object):
         if self.cache is not None and (n, key) in self.cache:
             return self.cache[n, key]
 
-        out = safe_indexing(x, self.splits[n][0]) if _is_arraylike(x) else x
+        out = (
+            safe_indexing(x, self.splits[n][0])
+            if _should_pack_fit_param(x) and not isinstance(x, list)
+            else x
+        )
 
         if self.cache is not None:
             self.cache[n, key] = out

--- a/dask_ml/model_selection/methods.py
+++ b/dask_ml/model_selection/methods.py
@@ -13,7 +13,7 @@ from scipy.stats import rankdata
 from sklearn.exceptions import FitFailedWarning
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.utils import safe_indexing
-from sklearn.utils.validation import _is_arraylike, check_consistent_length
+from sklearn.utils.validation import check_consistent_length
 from toolz import pluck
 
 from .utils import _should_pack_fit_param, copy_estimator

--- a/dask_ml/model_selection/methods.py
+++ b/dask_ml/model_selection/methods.py
@@ -108,11 +108,7 @@ class CVCache(object):
         if self.cache is not None and (n, key) in self.cache:
             return self.cache[n, key]
 
-        out = (
-            safe_indexing(x, self.splits[n][0])
-            if _should_pack_fit_param(x) and not isinstance(x, list)
-            else x
-        )
+        out = safe_indexing(x, self.splits[n][0]) if _should_pack_fit_param(x) else x
 
         if self.cache is not None:
             self.cache[n, key] = out

--- a/dask_ml/model_selection/utils.py
+++ b/dask_ml/model_selection/utils.py
@@ -53,7 +53,13 @@ def to_indexable(*args, **kwargs):
 
 
 def _index_param_value(num_samples, v, indices):
-    """Private helper function for parameter value indexing."""
+    """Private helper function for parameter value indexing.
+
+    This determines whether a fit parameter `v` to a SearchCV.fit
+    should be indexed along with `X` and `y`. Note that this differs
+    from the scikit-learn version. They pass `X` and compute num_samples.
+    We pass `num_samples` instead.
+    """
     if not _is_arraylike(v) or _num_samples(v) != num_samples:
         # pass through: skip indexing
         return v

--- a/dask_ml/model_selection/utils.py
+++ b/dask_ml/model_selection/utils.py
@@ -21,7 +21,7 @@ def _indexable(x):
 
 
 def _maybe_indexable(x):
-    return indexable(x)[0] if _is_arraylike(x) else x
+    return indexable(x)[0] if _should_pack_fit_param(x) else x
 
 
 def to_indexable(*args, **kwargs):
@@ -46,6 +46,16 @@ def to_indexable(*args, **kwargs):
             yield delayed(indexable, pure=True)(x)
         else:
             yield indexable(x)
+
+
+def _is_arraylike(x):
+    """Returns whether the input is array-like"""
+    # from scikit-learn
+    return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
+
+
+def _should_pack_fit_param(x):
+    return _is_arraylike(x) and not isinstance(x, list)
 
 
 def to_keys(dsk, *args):

--- a/dask_ml/model_selection/utils.py
+++ b/dask_ml/model_selection/utils.py
@@ -48,12 +48,6 @@ def to_indexable(*args, **kwargs):
             yield indexable(x)
 
 
-def _is_arraylike(x):
-    """Returns whether the input is array-like"""
-    # from scikit-learn
-    return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
-
-
 def _should_pack_fit_param(x):
     return _is_arraylike(x) and not isinstance(x, list)
 

--- a/dask_ml/model_selection/utils_test.py
+++ b/dask_ml/model_selection/utils_test.py
@@ -45,6 +45,15 @@ class MockClassifier(object):
         return self
 
 
+class MockClassifierWithFitParam(MockClassifier):
+    """A mock classifier with a required fit param."""
+
+    def fit(self, X, y, mock_fit_param=None):
+        if mock_fit_param is None:
+            raise ValueError("Requires non-None 'mock_fit_param'")
+        return super(MockClassifierWithFitParam, self)
+
+
 class ScalingTransformer(BaseEstimator):
     def __init__(self, factor=1):
         self.factor = factor

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -7,6 +7,7 @@ from multiprocessing import cpu_count
 from numbers import Integral
 from timeit import default_timer as tic
 
+import dask
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
@@ -302,6 +303,14 @@ def _timed(_logger=None, level="info"):
         return wraps
 
     return fun_wrapper
+
+
+def _num_samples(X):
+    result = sk_validation._num_samples(X)
+    if dask.is_dask_collection(result):
+        # dask dataframe
+        result = result.compute()
+    return result
 
 
 __all__ = [

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Enhancements
 
 - Automatically replace default scikit-learn scorers with dask-aware versions in Incremental (:issue:`200`)
 - Added the :func:`dask_ml.metrics.log_loss` loss function and ``neg_log_loss`` scorer (:pr:`318`)
+- Fixed handling of array-like fit-parameters to GridSearchCV and BaseSearchCV (:pr:`320`)
 
 Bug Fixes
 ---------

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ ignore =
 
 [isort]
 known_first_party=dask_ml
-known_third_party=sklearn,dask,distributed,dask_glm,pandas,coloredlogs,git,packaging.version,packaging,numpy,pytest,scipy,six
+known_third_party=sklearn,dask,distributed,dask_glm,pandas,coloredlogs,git,packaging.version,packaging,numpy,pytest,scipy,six,toolz
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -49,6 +49,7 @@ from dask_ml.model_selection.utils_test import (
     CheckXClassifier,
     FailingClassifier,
     MockClassifier,
+    MockClassifierWithFitParam,
     ScalingTransformer,
     ignore_warnings,
 )
@@ -807,3 +808,19 @@ def test_cv_multiplemetrics_no_refit():
     assert hasattr(a, "best_index_") is hasattr(b, "best_index_")
     assert hasattr(a, "best_estimator_") is hasattr(b, "best_estimator_")
     assert hasattr(a, "best_score_") is hasattr(b, "best_score_")
+
+
+def test_gridsearch_pipeline_with_arraylike_fit_param():
+    # https://github.com/dask/dask-ml/issues/319
+    X, y = make_classification(random_state=0)
+    param_grid = {"foo_param": [0.0001, 0.1]}
+
+    a = dcv.GridSearchCV(
+        MockClassifierWithFitParam(), param_grid, cv=3, iid=False, refit=False
+    )
+    b = GridSearchCV(
+        MockClassifierWithFitParam(), param_grid, cv=3, iid=False, refit=False
+    )
+
+    b.fit(X, y, mock_fit_param=[0, 1])
+    a.fit(X, y, mock_fit_param=[0, 1])

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -810,13 +810,19 @@ def test_cv_multiplemetrics_no_refit():
     assert hasattr(a, "best_score_") is hasattr(b, "best_score_")
 
 
-def test_gridsearch_pipeline_with_arraylike_fit_param():
+@pytest.mark.parametrize("cache_cv", [True, False])
+def test_gridsearch_with_arraylike_fit_param(cache_cv):
     # https://github.com/dask/dask-ml/issues/319
     X, y = make_classification(random_state=0)
     param_grid = {"foo_param": [0.0001, 0.1]}
 
     a = dcv.GridSearchCV(
-        MockClassifierWithFitParam(), param_grid, cv=3, iid=False, refit=False
+        MockClassifierWithFitParam(),
+        param_grid,
+        cv=3,
+        iid=False,
+        refit=False,
+        cache_cv=cache_cv,
     )
     b = GridSearchCV(
         MockClassifierWithFitParam(), param_grid, cv=3, iid=False, refit=False

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -824,3 +824,12 @@ def test_gridsearch_pipeline_with_arraylike_fit_param():
 
     b.fit(X, y, mock_fit_param=[0, 1])
     a.fit(X, y, mock_fit_param=[0, 1])
+
+
+def test_mock_with_fit_param_raises():
+    X, y = make_classification(random_state=0)
+
+    clf = MockClassifierWithFitParam()
+
+    with pytest.raises(ValueError):
+        clf.fit(X, y)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from dask.dataframe.utils import assert_eq as assert_eq_df
 
 from dask_ml.datasets import make_classification
 from dask_ml.utils import (
+    _num_samples,
     assert_estimator_equal,
     check_array,
     check_chunks,
@@ -159,3 +160,17 @@ def test_check_array_raises():
         check_array(X)
 
     assert m.match("Chunking is only allowed on the first axis.")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.random.uniform(size=10),
+        da.random.uniform(size=10, chunks=5),
+        da.random.uniform(size=(10, 4), chunks=5),
+        dd.from_pandas(pd.DataFrame({"A": range(10)}), npartitions=2),
+        dd.from_pandas(pd.Series(range(10)), npartitions=2),
+    ],
+)
+def test_num_samples(data):
+    assert _num_samples(data) == 10


### PR DESCRIPTION
This is an incorrect fix for #319.

Hadcoding `list` as the only arraylike thing that isn't sent through `_indexable` isn't right, but I'm not sure what else should be exempted. Mainly because I don't yet understand  the purpose of `to_indexable`.

cc @jcrist do you have any thoughts here?

Closes #319 


