### PR TITLE
Log loss shapes

### DIFF
--- a/dask_ml/metrics/classification.py
+++ b/dask_ml/metrics/classification.py
@@ -1,3 +1,4 @@
+import dask
 import dask.array as da
 import numpy as np
 import packaging.version
@@ -109,6 +110,16 @@ def _log_loss_inner(x, y, sample_weight, **kwargs):
 def log_loss(
     y_true, y_pred, eps=1e-15, normalize=True, sample_weight=None, labels=None
 ):
+    if not (dask.is_dask_collection(y_true) and dask.is_dask_collection(y_pred)):
+        return sklearn.metrics.log_loss(
+            y_true,
+            y_pred,
+            eps=eps,
+            normalize=normalize,
+            sample_weight=sample_weight,
+            labels=labels,
+        )
+
     if y_pred.ndim > 1 and y_true.ndim == 1:
         y_true = y_true.reshape(-1, 1)
         drop_axis = 1

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -87,7 +87,8 @@ def test_pairwise_kernels(kernel):
 @pytest.mark.parametrize("sample_weight", [True, False])
 @pytest.mark.parametrize("normalize", [True, False])
 @pytest.mark.parametrize("labels", [[0, 1], [0, 1, 3], [1, 0]])
-def test_log_loss(labels, normalize, sample_weight):
+@pytest.mark.parametrize("daskify", [True, False])
+def test_log_loss(labels, normalize, sample_weight, daskify):
     n = 100
     c = 25
     y_true = np.random.choice(labels, size=n)
@@ -102,8 +103,13 @@ def test_log_loss(labels, normalize, sample_weight):
         sample_weight = None
         dsample_weight = None
 
-    dy_true = da.from_array(y_true, chunks=c)
-    dy_pred = da.from_array(y_pred, chunks=c)
+    if daskify:
+        dy_true = da.from_array(y_true, chunks=c)
+        dy_pred = da.from_array(y_pred, chunks=c)
+    else:
+        dy_true = y_true
+        dy_pred = y_pred
+        dsample_weight, = dask.compute(dsample_weight)
 
     a = sklearn.metrics.log_loss(
         y_true, y_pred, normalize=normalize, sample_weight=sample_weight


### PR DESCRIPTION
This fixes the shape handling for `log_loss`.

There are two modes: depending on the shape of `y_pred`, previously we just handled the `y_pred.shape == (n_samples, n_classes)` case. Now we handle `(n_samples,)`, which is assumed to be the probability of the positive class (binary only).