### PR TITLE
Base class for estimators using _incremental.fit

### DIFF
--- a/dask_ml/feature_extraction/text.py
+++ b/dask_ml/feature_extraction/text.py
@@ -33,7 +33,7 @@ class HashingVectorizer(sklearn.feature_extraction.text.HashingVectorizer):
         blocks to ndarrays or pydata/sparse matricies.
 
         >>> import sparse
-        >>> X.map_blocks(sparse.COO.from_scipy_sparse)  # doctest: +SKIP
+        >>> X.map_blocks(sparse.COO.from_scipy_sparse, dtype=X.dtype)  # doctest: +SKIP
 
         See the :doc:`examples/text-vectorization` for more.
         """

--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -16,3 +16,14 @@ __all__ = [
     "compute_n_splits",
     "check_cv",
 ]
+
+
+try:
+    from ._incremental import (  # noqa: F401
+        RandomizedIncrementalSearch,
+        SuccessiveReductionSearch,
+    )
+
+    __all__.extend(["RandomizedIncrementalSearch", "SuccessiveReductionSearch"])
+except ImportError:
+    pass

--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -19,11 +19,8 @@ __all__ = [
 
 
 try:
-    from ._incremental import (  # noqa: F401
-        RandomizedIncrementalSearch,
-        ExponentialDecaySearch,
-    )
+    from ._incremental import IncrementalSearch  # noqa: F401
 
-    __all__.extend(["RandomizedIncrementalSearch", "ExponentialDecaySearch"])
+    __all__.extend(["IncrementalSearch"])
 except ImportError:
     pass

--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -21,9 +21,9 @@ __all__ = [
 try:
     from ._incremental import (  # noqa: F401
         RandomizedIncrementalSearch,
-        SuccessiveReductionSearch,
+        ExponentialDecaySearch,
     )
 
-    __all__.extend(["RandomizedIncrementalSearch", "SuccessiveReductionSearch"])
+    __all__.extend(["RandomizedIncrementalSearch", "ExponentialDecaySearch"])
 except ImportError:
     pass

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -547,10 +547,21 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         cv_results = self._get_cv_results(results)
         best_estimator, best_index = self._get_best(results, cv_results)
 
+        # Clean up models we're hanging onto
+        ids = [
+            (loop_id, model_id)
+            for loop_id in results
+            for model_id in results[loop_id][1]
+        ]
+        for (loop_id, model_id) in ids:
+            del results[loop_id][1][model_id]
+
         self.scoring_ = scorer
         self.cv_results_ = cv_results
         self.best_estimator_ = best_estimator
         self.best_index_ = best_index
+        self.n_splits_ = 1
+        self.multimetric_ = False  # TODO: is this always true?
         return self
 
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -45,6 +45,28 @@ def _partial_fit(model_and_meta, X, y, fit_params):
         * info : Dict[model_id, List[Dict]]
             Keys are integers identifying each model. Values are a
             List of Dictk
+        * models : Dict[model_id, Future[Estimator]]
+            A dictionary with the same keys as `info`. The values
+            are futures to the fitted models.
+        * history : List[Dict]
+            The history of model fitting for each model. Each element
+            of the list is a dictionary with the following elements:
+
+            'model_id', 'params', 'partial_fit_calls', 'partial_fit_time', 'score', 'score_time'])
+
+            * model_id : int
+                A superset of the keys for `info` and `models`.
+            * params : Dict[str, Any]
+                Parameters this model was trained with. 
+            * partial_fit_calls : int
+                The number of *consecutive* partial fit calls at this stage in
+                this models training history.
+            * partial_fit_time : float
+                Time (in seconds) spent on this partial fit
+            * score : float
+                Score on the test set for the model at this point in history
+            * score_time : float
+                Time (in seconds) spent on this scoring.
     """
     with log_errors():
         start = time()

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import itertools
 import operator
+from collections import namedtuple
 from copy import deepcopy
 from time import time
 
@@ -21,6 +22,8 @@ from ..utils import check_array
 from ._search import _RETURN_TRAIN_SCORE_DEFAULT, DaskBaseSearchCV
 from ._split import train_test_split
 
+Results = namedtuple("Results", ["info", "models", "history"])
+
 
 def _partial_fit(model_and_meta, X, y, fit_params):
     """
@@ -36,10 +39,12 @@ def _partial_fit(model_and_meta, X, y, fit_params):
 
     Returns
     -------
-    model : Estimator
-        The model that has been fit.
-    meta : dict
-        A new dictionary with updated information.
+    Results
+        A named tuple with three fields: info, models, history
+
+        * info : Dict[model_id, List[Dict]]
+            Keys are integers identifying each model. Values are a
+            List of Dictk
     """
     with log_errors():
         start = time()
@@ -229,7 +234,7 @@ def _fit(
 
     models = {k: client.submit(operator.getitem, v, 0) for k, v in models.items()}
     yield wait(models)
-    raise gen.Return((info, models, history))
+    raise gen.Return(Results(info, models, history))
 
 
 def fit(
@@ -363,14 +368,12 @@ def fit(
 # ----------------------------------------------------------------------------
 
 
-class BaseIncrementalSearchCV(DaskBaseSearchCV):
+class BaseIncrementalSearch(DaskBaseSearchCV):
     """Base class for estimators using the incremental `fit`.
 
     Subclasses must implement the following abstract method
 
-    * _get_ids_and_args : Build the dict of
-       ``{model_id : (param_list, additional_calls)}``
-        that are eventually passed to `fit`
+    * _additional_calls
     """
 
     def __init__(
@@ -382,7 +385,6 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         scoring=None,
         iid=True,
         refit=True,
-        cv=None,
         error_score="raise",
         return_train_score=_RETURN_TRAIN_SCORE_DEFAULT,
         scheduler=None,
@@ -393,12 +395,11 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         self.params = params
         self.test_size = test_size
         self.random_state = random_state
-        super(BaseIncrementalSearchCV, self).__init__(
+        super(BaseIncrementalSearch, self).__init__(
             estimator,
             scoring=scoring,
             iid=iid,
             refit=refit,
-            cv=cv,
             error_score=error_score,
             return_train_score=return_train_score,
             scheduler=scheduler,
@@ -420,10 +421,11 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         if isinstance(y, np.ndarray):
             y = da.from_array(y, y.shape)
         X = check_array(X, **kwargs)
+        kwargs["ensure_2d"] = False
         y = check_array(y, **kwargs)
         return X, y
 
-    def _get_cv(self, X, y, **kwargs):
+    def _get_train_test_split(self, X, y, **kwargs):
         """CV-Split the arrays X and y
 
         By default, :meth:`dask_ml.model_selection.train_test_split`
@@ -439,25 +441,16 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         )
         return X_train, X_test, y_train, y_test
 
-    def _get_ids_and_args(self):
-        # type: () -> Dict[int, Tuple(List[Dict], Union[Callable, object])]
-        """Abstract method for generating the argumnets passed to `fit`.
-
-        Returns
-        -------
-        ids_and_args : Dict
-            Should have integers for keys and the following arguments
-
-            * param_list : List[Dict]
-            * additional_fit_calls : Union[Callable, object]
-                Objects with a ``fit`` method have the bound
-                ``additional_fit_calls.fit`` method passed through to `fit`.
-                (Other) callables are simply passed through.
-        """
+    def _additional_calls(self):
         raise NotImplementedError
 
-    def _get_cv_results(self, results):
-        # type: (Dict) -> Dict
+    def _get_params(self):
+        # I don't think there's really a good default here.
+        # This assume random search. Could equally do grid search.
+        return ParameterSampler(self.params, self.n_iter)
+
+    def _get_history_results(self, results):
+        # type: (Results) -> Dict
         """Construct the CV results.
 
         Has the following keys:
@@ -473,62 +466,26 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         * partial_fit_calls
         * model_id
         """
-        info, model, history = zip(*results.values())
-        info = list(itertools.chain.from_iterable(x.values() for x in info))
-        model = list(itertools.chain.from_iterable(x.values() for x in model))
-        history = list(itertools.chain.from_iterable(history))
+        info, model, history = results
+        key = operator.itemgetter("model_id")
+        hist2 = sorted(history, key=key)
+        return hist2
 
-        scores = np.array([x["score"] for v in info for x in v])
-        ranks = np.argsort(-1 * scores) + 1
-        assert max(scores) == scores[ranks - 1][0]
-        model_ids = []
-        for loop_id in results:
-            loop_info = results[loop_id][0]
-            model_ids.extend(
-                [
-                    "{}-{}".format(loop_id, x["model_id"])
-                    for v in loop_info.values()
-                    for x in v
-                ]
-            )
-
-        cv_results = {
-            "params": [x["params"] for v in info for x in v],
-            "test_score": scores,
-            "mean_test_score": scores,  # for sklearn comptability
-            "rank_test_score": ranks,
-            "mean_partial_fit_time": np.array(
-                [np.mean(x["partial_fit_time"]) for v in info for x in v]
-            ),
-            "std_partial_fit_time": np.array(
-                [np.std(x["partial_fit_time"]) for v in info for x in v]
-            ),
-            "mean_score_time": np.array(
-                [np.mean(x["score_time"]) for v in info for x in v]
-            ),
-            "std_score_time": np.array(
-                [np.std(x["score_time"]) for v in info for x in v]
-            ),
-            "partial_fit_calls": [x["partial_fit_calls"] for v in info for x in v],
-            "model_id": model_ids,
-        }
-        return cv_results
-
-    def _get_best(self, results, cv_results):
+    def _get_best(self, results, history_results):
         # type: (Dict, Dict) -> Estimator
         """Select the best estimator from the set of estimators."""
-        rank = cv_results["rank_test_score"]
-        best_index = np.arange(len(rank))[rank - 1][0]
-        best_model_id = cv_results["model_id"][best_index]
-        assert cv_results["test_score"][best_index] == max(cv_results["test_score"])
+        best_model_id = first(results.info)
+        key = operator.itemgetter("model_id")
+        best_index = 0
+        # history_results is sorted by (model_id, partial_fit_calls)
+        # best is the model_id with the highest partial fit calls
+        for k, v in itertools.groupby(history_results, key=key):
+            v = list(v)
+            best_index += len(v)
+            if k == v:
+                break
 
-        loop_id, model_id = map(int, best_model_id.split("-"))
-        return results[loop_id][1][model_id].result(), best_index
-
-    def _update_results(self, results):
-        # type: (Dict) -> None
-        """Update `self` with attributes extracted from `results`."""
-        pass
+        return results.models[best_model_id], best_index
 
     def _process_results(self, results):
         """Called with the output of `fit` immediately after it finishes.
@@ -541,7 +498,7 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         return results
 
     def fit(self, X, y, **fit_params):
-        """Find the best parameters for a particular model
+        """Find the best parameters for a particular model.
 
         Parameters
         ----------
@@ -549,43 +506,34 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         **fit_params
             Additional partial fit keyword arguments for the estimator.
         """
-        ids_and_args = self._get_ids_and_args()
-        X, y = check_array(X, y)
+        X, y = self._check_array(X, y)
 
-        X_train, X_test, y_train, y_test = self._get_cv(X, y)
+        X_train, X_test, y_train, y_test = self._get_train_test_split(X, y)
         scorer = check_scoring(self.estimator, scoring=self.scoring)
 
-        results = {
-            model_id: fit(
-                self.estimator,
-                param_list,
-                X_train,
-                y_train,
-                X_test,
-                y_test,
-                additional_calls=getattr(additional_calls, "fit", additional_calls),
-                fit_params=fit_params,
-                scorer=scorer,
-                random_state=self.random_state,
-            )
-            for model_id, (param_list, additional_calls) in ids_and_args.items()
-        }
+        results = fit(
+            self.estimator,
+            self._get_params(),
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            additional_calls=self._additional_calls,
+            fit_params=fit_params,
+            scorer=scorer,
+            random_state=self.random_state,
+        )
         results = self._process_results(results)
-        self._update_results(results)
-        cv_results = self._get_cv_results(results)
-        best_estimator, best_index = self._get_best(results, cv_results)
+        history_results = self._get_history_results(results)
+        best_estimator, best_index = self._get_best(results, history_results)
 
         # Clean up models we're hanging onto
-        ids = [
-            (loop_id, model_id)
-            for loop_id in results
-            for model_id in results[loop_id][1]
-        ]
-        for (loop_id, model_id) in ids:
-            del results[loop_id][1][model_id]
+        ids = list(results.models)
+        for model_id in ids:
+            del results.models[model_id]
 
         self.scoring_ = scorer
-        self.cv_results_ = cv_results
+        self.history_results_ = history_results
         self.best_estimator_ = best_estimator
         self.best_index_ = best_index
         self.n_splits_ = 1
@@ -593,7 +541,7 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
         return self
 
 
-class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
+class WorstIncrementalSearch(BaseIncrementalSearch):
     def __init__(
         self,
         estimator,
@@ -604,7 +552,6 @@ class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
         scoring=None,
         iid=True,
         refit=True,
-        cv=None,
         error_score="raise",
         return_train_score=_RETURN_TRAIN_SCORE_DEFAULT,
         scheduler=None,
@@ -612,7 +559,7 @@ class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
         cache_cv=True,
     ):
         self.n_iter = 10
-        super(IncrementalRandomizedSearchCV, self).__init__(
+        super(WorstIncrementalSearch, self).__init__(
             estimator,
             param_distribution,
             test_size,
@@ -620,7 +567,6 @@ class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
             scoring,
             iid,
             refit,
-            cv,
             error_score,
             return_train_score,
             scheduler,
@@ -628,30 +574,22 @@ class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
             cache_cv,
         )
 
-    def _get_ids_and_args(self):
-        return {0: (ParameterSampler(self.params, self.n_iter), remove_worst)}
+    def _additional_calls(self, scores):
+        """Default `additional_calls` strategy for IncrementalSearch.
 
-    def _update_results(self, results):
-        self.info_, _, self.history_ = results[0]
+        Removes the lowest scoring model from a batch of models.
+        """
+        last_score = {model_id: info[-1]["score"] for model_id, info in scores.items()}
+        worst_score = min(last_score.values())
+        out = {}
+        for model_id, score in last_score.items():
+            if score != worst_score:
+                out[model_id] = 1  # do one more training step
 
-
-def remove_worst(scores):
-    # type: Dict[Int, Dict] -> Dict[Int, Int]
-    """Default `additional_calls` strategy for IncrementalSearch.
-
-    Removes the lowest scoring model from a batch of models.
-    """
-    last_score = {model_id: info[-1]["score"] for model_id, info in scores.items()}
-    worst_score = min(last_score.values())
-    out = {}
-    for model_id, score in last_score.items():
-        if score != worst_score:
-            out[model_id] = 1  # do one more training step
-
-    if len(out) == 0:
-        # we have a tie where each model is equal to the worst.
-        # Arbitrarily pick the first.
-        out = {first(last_score): 0}
-    elif len(out) == 1:
-        out = {k: 0 for k in out}  # no more work to do, stops execution
-    return out
+        if len(out) == 0:
+            # we have a tie where each model is equal to the worst.
+            # Arbitrarily pick the first.
+            out = {first(last_score): 0}
+        elif len(out) == 1:
+            out = {k: 0 for k in out}  # no more work to do, stops execution
+        return out

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -52,12 +52,10 @@ def _partial_fit(model_and_meta, X, y, fit_params):
             The history of model fitting for each model. Each element
             of the list is a dictionary with the following elements:
 
-            'model_id', 'params', 'partial_fit_calls', 'partial_fit_time', 'score', 'score_time'])
-
             * model_id : int
                 A superset of the keys for `info` and `models`.
             * params : Dict[str, Any]
-                Parameters this model was trained with. 
+                Parameters this model was trained with.
             * partial_fit_calls : int
                 The number of *consecutive* partial fit calls at this stage in
                 this models training history.

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -366,16 +366,11 @@ def fit(
 class BaseIncrementalSearchCV(DaskBaseSearchCV):
     """Base class for estimators using the incremental `fit`.
 
-    Subclasses must implement the following abstract methods
+    Subclasses must implement the following abstract method
 
     * _get_ids_and_args : Build the dict of
        ``{model_id : (param_list, additional_calls)}``
         that are eventually passed to `fit`
-    * _get_cv_results : Build the dict containing the CV results.
-    * _get_best_estimator : Select the best estimator from the set of
-      fitted estimators
-    * _update_results : Update self with attributes from the fitted
-      esimators.
     """
 
     def __init__(

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -621,9 +621,9 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         method for sampling (such as those from scipy.stats.distributions).
         If a list is given, it is sampled uniformly.
 
-    n_iter : int, default=10
-        Number of parameter settings that are sampled. n_iter trades
-        off runtime vs quality of the solution.
+    n_initial_parameters : int, default=10
+        Number of parameter settings that are sampled. n_initial_parameters
+        trades off runtime vs quality of the solution.
 
     max_iter : int, default 100
         Maximum number of partial fit iterations per model. This is passed
@@ -714,7 +714,7 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         self,
         estimator,
         param_distribution,
-        n_iter=10,
+        n_initial_parameters=10,
         max_iter=100,
         patience=10,
         tol=0.001,
@@ -730,7 +730,7 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         cache_cv=True,
     ):
         self.max_iter = max_iter
-        self.n_iter = n_iter
+        self.n_initial_parameters = n_initial_parameters
         self.patience = patience
         self.tol = tol
         super(RandomizedIncrementalSearch, self).__init__(
@@ -749,7 +749,7 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         )
 
     def _get_params(self):
-        return ParameterSampler(self.parameters, self.n_iter)
+        return ParameterSampler(self.parameters, self.n_initial_parameters)
 
     def _additional_calls(self, info):
         out = {}
@@ -805,9 +805,9 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         method for sampling (such as those from scipy.stats.distributions).
         If a list is given, it is sampled uniformly.
 
-    n_iter : int, default=10
-        Number of parameter settings that are sampled. n_iter trades
-        off runtime vs quality of the solution.
+    n_initial_parameters : int, default=10
+        Number of parameter settings that are sampled. n_initial_parameters
+        trades off runtime vs quality of the solution.
 
     max_iter : int, default 100
         Maximum number of partial fit iterations per model. This is passed
@@ -879,7 +879,7 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         self,
         estimator,
         param_distribution,
-        n_iter=10,
+        n_initial_parameters=10,
         max_iter=100,
         decay_rate=1.0,
         test_size=0.15,
@@ -894,7 +894,7 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         cache_cv=True,
     ):
         self.max_iter = max_iter
-        self.n_iter = n_iter
+        self.n_initial_parameters = n_initial_parameters
         self.decay_rate = decay_rate
         super(SuccessiveReductionSearch, self).__init__(
             estimator,
@@ -912,12 +912,12 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         )
 
     def _get_params(self):
-        return ParameterSampler(self.parameters, self.n_iter)
+        return ParameterSampler(self.parameters, self.n_initial_parameters)
 
     def _additional_calls(self, info):
         def inverse(time):
             """ Decrease target number of models inversely with time """
-            return int(self.n_iter / (1 + time) ** self.decay_rate)
+            return int(self.n_initial_parameters / (1 + time) ** self.decay_rate)
 
         example = toolz.first(info.values())
         time_step = example[-1]["partial_fit_calls"]

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -473,9 +473,6 @@ class BaseIncrementalSearchCV(DaskBaseSearchCV):
                 ]
             )
 
-        assert len(model_ids) == len(scores)
-        # assert len(set(model_ids)) == len(model_ids)
-
         cv_results = {
             "params": [x["params"] for v in info for x in v],
             "test_score": scores,

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -465,9 +465,11 @@ class BaseIncrementalSearch(DaskBaseSearchCV):
         raise NotImplementedError
 
     def _get_params(self):
-        # I don't think there's really a good default here.
-        # This assume random search. Could equally do grid search.
-        return ParameterGrid(self.params)
+        """Parameters to pass to `fit`.
+
+        By defualt, a GridSearch over ``self.parameters`` is used.
+        """
+        return ParameterGrid(self.parameters)
 
     def _get_history_results(self, results):
         # type: (Results) -> Dict

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -604,7 +604,7 @@ class IncrementalRandomizedSearchCV(BaseIncrementalSearchCV):
         return {0: (ParameterSampler(self.params, self.n_iter), remove_worst)}
 
     def _update_results(self, results):
-        self.info_, self.models_, self.history_ = results[0]
+        self.info_, _, self.history_ = results[0]
 
 
 def remove_worst(scores):

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -313,7 +313,7 @@ def fit(
     See Also
     --------
     RandomIncrementalSearch
-    SuccessiveReductionSearch
+    ExponentialDecaySearch
 
     Examples
     --------
@@ -773,7 +773,7 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         return out
 
 
-class SuccessiveReductionSearch(BaseIncrementalSearch):
+class ExponentialDecaySearch(BaseIncrementalSearch):
     """ Search incrementally trained models, preferring well-performing models
 
     This incremental hyper-parameter optimization class starts training the
@@ -880,9 +880,9 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
     ...           'l1_ratio': np.linspace(0, 1, num=1000),
     ...           'average': [True, False]}
 
-    >>> search = SuccessiveReductionSearch(model, params, random_state=0)
+    >>> search = ExponentialDecaySearch(model, params, random_state=0)
     >>> search.fit(X, y, classes=[0, 1])
-    SuccessiveReductionSearch(...)
+    ExponentialDecaySearch(...)
     """
 
     def __init__(
@@ -910,7 +910,7 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         self.patience = patience
         self.tol = tol
         self.scores_per_fit = scores_per_fit
-        super(SuccessiveReductionSearch, self).__init__(
+        super(ExponentialDecaySearch, self).__init__(
             estimator,
             param_distribution,
             test_size,

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -405,7 +405,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
     """
 
     def __init__(
-        self, estimator, parameters, test_size=0.15, random_state=None, scoring=None
+        self, estimator, parameters, test_size=None, random_state=None, scoring=None
     ):
         self.estimator = estimator
         self.parameters = parameters
@@ -442,9 +442,11 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
         ----------
         X, y : dask.array.Array
         """
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, test_size=self.test_size
-        )
+        if self.test_size is None:
+            test_size = 1 / X.npartitions
+        else:
+            test_size = self.test_size
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size)
         return X_train, X_test, y_train, y_test
 
     def _additional_calls(self, info):
@@ -662,6 +664,7 @@ class IncrementalSearch(BaseIncrementalSearch):
 
     test_size : float
         Fraction of the dataset to hold out for computing test scores.
+        Defaults to the size of a single partition of the input training set
 
         .. note::
 
@@ -730,7 +733,7 @@ class IncrementalSearch(BaseIncrementalSearch):
         param_distribution,
         n_initial_parameters=10,
         decay_rate=1.0,
-        test_size=0.15,
+        test_size=None,
         patience=False,
         tol=0.001,
         scores_per_fit=1,

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -310,11 +310,6 @@ def fit(
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    See Also
-    --------
-    RandomIncrementalSearch
-    ExponentialDecaySearch
-
     Examples
     --------
     >>> import numpy as np
@@ -602,164 +597,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
         return self.scorer_(self.best_estimator_, X, y)
 
 
-class RandomizedIncrementalSearch(BaseIncrementalSearch):
-    """Incremental optimization with randomly sampled hyperparameters.
-
-    Incrementally hyper-parameter optimization creates a batch of models
-    and repeatedly call `partial_fit` with batches of data. The performance
-    of each model is monitored over time.
-
-    The set of hyper-parameters considered are randomly sampled from the
-    provided `param_distribution`.
-
-    Models are prioritized according to three parameters: `tol`, `patience`
-    and `max_iter`. Models are repeatedly trained until their score on the
-    test set stops improving. The last `patience` (10 by default) partial
-    fit iterations are considered. If the improvement is small (less than)
-    `tol`, training on that model is halted. If `max_iter` iterations is
-    reached training is halted, regardless of whether the model is still
-    improving.
-
-    Parameters
-    ----------
-    estimator : estimator object.
-        A object of that type is instantiated for each grid point.
-        This is assumed to implement the scikit-learn estimator interface.
-        Either estimator needs to provide a `score`` function,
-        or ``scoring`` must be passed. The estimator must implement
-        ``partial_fit``.
-
-    param_distributions : dict
-        Dictionary with parameters names (string) as keys and distributions
-        or lists of parameters to try. Distributions must provide a ``rvs``
-        method for sampling (such as those from scipy.stats.distributions).
-        If a list is given, it is sampled uniformly.
-
-    n_initial_parameters : int, default=10
-        Number of parameter settings that are sampled. n_initial_parameters
-        trades off runtime vs quality of the solution.
-
-    max_iter : int, default 100
-        Maximum number of partial fit iterations per model.
-
-    patience : int, default 10
-        The number of previous models scores to consider when determining
-        whether the model has converged. The most recent score must be at
-        at most `tol` better than the all of the previous `patience` scores.
-        Increasing `patience` will tend to provide better models, at the cost
-        of increased computation.
-
-    tol : float, default 0.001
-        The required level of improvement to consider stopping training on
-        that model. The most recent score must be at at most `tol` better
-        than the all of the previous `patience` scores for that model.
-        Increasing `tol` will tend to reduce training time, at the cost
-        of worse models.
-
-    test_size : float
-
-        Fraction of the dataset to hold out for computing test scores.
-
-        .. note::
-
-           The training dataset should fit in memory on a single machine.
-           Adjust the `test_size` parameter as necessary to achieve this.
-
-    random_state : int, RandomState instance or None, optional, default: None
-        If int, random_state is the seed used by the random number generator;
-        If RandomState instance, random_state is the random number generator;
-        If None, the random number generator is the RandomState instance used
-        by `np.random`.
-
-    scoring : string, callable, list/tuple, dict or None, default: None
-        A single string (see :ref:`scoring_parameter`) or a callable
-        (see :ref:`scoring`) to evaluate the predictions on the test set.
-
-        For evaluating multiple metrics, either give a list of (unique) strings
-        or a dict with names as keys and callables as values.
-
-        NOTE that when using custom scorers, each scorer should return a single
-        value. Metric functions returning a list/array of values can be wrapped
-        into multiple scorers that return one value each.
-
-        See :ref:`multimetric_grid_search` for an example.
-
-        If None, the estimator's default scorer (if available) is used.
-
-    Examples
-    --------
-    Connect to the client and create the data
-
-    >>> from dask.distributed import Client
-    >>> client = Client()
-    >>> import numpy as np
-    >>> from dask_ml.datasets import make_classification
-    >>> X, y = make_classification(n_samples=5000000, n_features=20,
-    ...                            chunks=100000, random_state=0)
-
-    Our underlying estimator is an SGDClassifier. We specify a few parameters
-    common to each clone of the estimator.
-
-    >>> from sklearn.linear_model import SGDClassifier
-    >>> model = SGDClassifier(tol=1e-3, penalty='elasticnet', random_state=0)
-
-    The distribution of parameters we'll sample from.
-
-    >>> params = {'alpha': np.logspace(-2, 1, num=1000),
-    ...           'l1_ratio': np.linspace(0, 1, num=1000),
-    ...           'average': [True, False]}
-
-    >>> search = RandomizedIncrementalSearch(model, params, random_state=0)
-    >>> search.fit(X, y, classes=[0, 1])
-    RandomizedIncrementalSearch(...)
-    """
-
-    def __init__(
-        self,
-        estimator,
-        param_distribution,
-        n_initial_parameters=10,
-        max_iter=100,
-        patience=10,
-        tol=0.001,
-        test_size=0.15,
-        random_state=None,
-        scoring=None,
-    ):
-        self.max_iter = max_iter
-        self.n_initial_parameters = n_initial_parameters
-        self.patience = patience
-        self.tol = tol
-        super(RandomizedIncrementalSearch, self).__init__(
-            estimator, param_distribution, test_size, random_state, scoring
-        )
-
-    def _get_params(self):
-        return ParameterSampler(self.parameters, self.n_initial_parameters)
-
-    def _additional_calls(self, info):
-        out = {}
-        max_iter = self.max_iter
-        patience = self.patience
-        tol = self.tol
-
-        for ident, records in info.items():
-            if max_iter is not None and len(records) > max_iter:
-                out[ident] = 0
-
-            elif len(records) > patience:
-                old = records[-patience]["score"]
-                if all(d["score"] < old + tol for d in records[-patience:]):
-                    out[ident] = 0
-                else:
-                    out[ident] = 1
-
-            else:
-                out[ident] = 1
-        return out
-
-
-class ExponentialDecaySearch(BaseIncrementalSearch):
+class IncrementalSearch(BaseIncrementalSearch):
     """ Search incrementally trained models, preferring well-performing models
 
     This incremental hyper-parameter optimization class starts training the
@@ -870,9 +708,9 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
     ...           'l1_ratio': np.linspace(0, 1, num=1000),
     ...           'average': [True, False]}
 
-    >>> search = ExponentialDecaySearch(model, params, random_state=0)
+    >>> search = IncrementalSearch(model, params, random_state=0)
     >>> search.fit(X, y, classes=[0, 1])
-    ExponentialDecaySearch(...)
+    IncrementalSearch(...)
     """
 
     def __init__(
@@ -895,7 +733,7 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         self.tol = tol
         self.scores_per_fit = scores_per_fit
         self.max_iter = max_iter
-        super(ExponentialDecaySearch, self).__init__(
+        super(IncrementalSearch, self).__init__(
             estimator, param_distribution, test_size, random_state, scoring
         )
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -443,7 +443,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
         X, y : dask.array.Array
         """
         if self.test_size is None:
-            test_size = 1 / X.npartitions
+            test_size = min(0.2, 1 / X.npartitions)
         else:
             test_size = self.test_size
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size)

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -486,7 +486,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
         """Select the best estimator from the set of estimators."""
         best_model_id = first(results.info)
         key = operator.itemgetter("model_id")
-        best_index = 0
+        best_index = -1
         # history_results is sorted by (model_id, partial_fit_calls)
         # best is the model_id with the highest partial fit calls
         for k, v in itertools.groupby(history_results, key=key):

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -626,7 +626,7 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
         trades off runtime vs quality of the solution.
 
     max_iter : int, default 100
-        Maximum number of partial fit iterations per model. This is passed
+        Maximum number of partial fit iterations per model.
 
     patience : int, default 10
         The number of previous models scores to consider when determining
@@ -827,6 +827,9 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         Increasing `tol` will tend to reduce training time, at the cost
         of worse models.
 
+    max_iter : int, default 100
+        Maximum number of partial fit iterations per model.
+
     test_size : float
 
         Fraction of the dataset to hold out for computing test scores.
@@ -895,6 +898,7 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         patience=False,
         tol=0.001,
         scores_per_fit=1,
+        max_iter=None,
         random_state=None,
         scoring=None,
         iid=True,
@@ -910,6 +914,7 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         self.patience = patience
         self.tol = tol
         self.scores_per_fit = scores_per_fit
+        self.max_iter = max_iter
         super(ExponentialDecaySearch, self).__init__(
             estimator,
             param_distribution,
@@ -941,7 +946,6 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         while (inverse(current_time_step) == inverse(next_time_step) and
                (not self.patience or
                    next_time_step - current_time_step < self.scores_per_fit)):
-
             next_time_step += 1
 
         target = inverse(next_time_step)
@@ -954,6 +958,8 @@ class ExponentialDecaySearch(BaseIncrementalSearch):
         out = {}
         for k in best:
             records = info[k]
+            if self.max_iter and len(records) >= self.max_iter:
+                out[k] = 0
             if self.patience and len(records) > self.patience:
                 old = records[-self.patience]["score"]
                 if all(d["score"] < old + self.tol for d in records[-self.patience:]):

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -790,7 +790,7 @@ class IncrementalSearch(BaseIncrementalSearch):
             records = info[k]
             if self.max_iter and len(records) >= self.max_iter:
                 out[k] = 0
-            if self.patience and len(records) > self.patience:
+            elif self.patience and len(records) > self.patience:
                 old = records[-self.patience]["score"]
                 if all(d["score"] < old + self.tol for d in records[-self.patience :]):
                     out[k] = 0

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -774,21 +774,20 @@ class RandomizedIncrementalSearch(BaseIncrementalSearch):
 
 
 class SuccessiveReductionSearch(BaseIncrementalSearch):
-    """Incremental optimization with randomly sampled hyperparameters.
+    """ Search incrementally trained models, preferring well-performing models
 
-    Incrementally hyper-parameter optimization creates a batch of models
-    and repeatedly call `partial_fit` with batches of data. The performance
-    of each model is monitored over time.
+    This incremental hyper-parameter optimization class starts training the
+    model on many randomly selected hyper-parameters on a small amount of data,
+    and then only continues training those models that seem to be performing
+    the best, decaying the number of activley trained models with an
+    exponential given by the initial number of parameters and the decay rate.
 
-    The set of hyper-parameters considered are randomly sampled from the
-    provided `param_distribution`.
+        n_models = n_initial_parameters * (n_batches ** -decay_rate)
 
-    Models are prioritized based on past performance. Models that have had
-    relatively more partial fit iterations in the past will be given
-    relatively fewer partial fit iterations in the future. The `decay_rate`
-    parameter controls how the number of future iterations decreases. If
-    `max_iter` iterations is reached training is halted, regardless of whether
-    that individual is still improving.
+    This method has two hyper-parameters:
+
+    1.  n_initial_parameters: The number of initial parameters to use
+    2.  decay_rate: The speed at which we decay
 
     Parameters
     ----------
@@ -808,9 +807,6 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
     n_initial_parameters : int, default=10
         Number of parameter settings that are sampled. n_initial_parameters
         trades off runtime vs quality of the solution.
-
-    max_iter : int, default 100
-        Maximum number of partial fit iterations per model. This is passed
 
     decay_rate : float, default 1.0
         How quickly to decrease the number partial future fit calls.
@@ -880,7 +876,6 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         estimator,
         param_distribution,
         n_initial_parameters=10,
-        max_iter=100,
         decay_rate=1.0,
         test_size=0.15,
         random_state=None,
@@ -893,7 +888,6 @@ class SuccessiveReductionSearch(BaseIncrementalSearch):
         n_jobs=-1,
         cache_cv=True,
     ):
-        self.max_iter = max_iter
         self.n_initial_parameters = n_initial_parameters
         self.decay_rate = decay_rate
         super(SuccessiveReductionSearch, self).__init__(

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -601,20 +601,27 @@ class IncrementalSearch(BaseIncrementalSearch):
     """
     Incrementally search for hyper-parameters on models that support partial_fit
 
+    .. note::
+
+       IncrementalSearch depends on the optional ``distributed`` library.
+
     This incremental hyper-parameter optimization class starts training the
     model on many hyper-parameters on a small amount of data, and then only
-    continues training those models that seem to be performing well,
-    decaying the number of actively trained models with an exponential given by
-    the initial number of parameters and the decay rate.
+    continues training those models that seem to be performing well.
+    The number of actively trained hyper-parameter combinations decays
+    with an exponential given by the initial number of parameters and the
+    decay rate.
 
         n_models = n_initial_parameters * (n_batches ** -decay_rate)
+
+    See the :ref:`User Guide <hyperparameter.incremental>` for more.
 
     Parameters
     ----------
     estimator : estimator object.
-        A object of that type is instantiated for each grid point.
-        This is assumed to implement the scikit-learn estimator interface.
-        Either estimator needs to provide a `score`` function,
+        A object of that type is instantiated for each initial hyperparameter
+        combination. This is assumed to implement the scikit-learn estimator
+        interface. Either estimator needs to provide a `score`` function,
         or ``scoring`` must be passed. The estimator must implement
         ``partial_fit``, ``set_params``, and work well with ``clone``.
 
@@ -636,8 +643,8 @@ class IncrementalSearch(BaseIncrementalSearch):
         of worse models.
 
     patience : int, default False
-        Maximum number of non-improving scores before we stop training a model
-        Off by default
+        Maximum number of non-improving scores before we stop training a
+        model. Off by default.
 
     scores_per_fit : int, default 1
         If ``patience`` is used the maximum number of ``partial_fit`` calls

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -790,7 +790,7 @@ class IncrementalSearch(BaseIncrementalSearch):
             records = info[k]
             if self.max_iter and len(records) >= self.max_iter:
                 out[k] = 0
-            elif self.patience and len(records) > self.patience:
+            elif self.patience and len(records) >= self.patience:
                 old = records[-self.patience]["score"]
                 if all(d["score"] < old + self.tol for d in records[-self.patience :]):
                     out[k] = 0

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -53,7 +53,9 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
 
        This class is not appropriate for parallel or distributed *training*
        on large datasets. For that, see :class:`Incremental`, which provides
-       distributed (but sequential) training.
+       distributed (but sequential) training. If you're doing distributed
+       hyperparameter optimization on larger-than-memory datasets, see
+       :class:`dask_ml.model_selection.IncrementalSearch`.
 
     This estimator does not parallelize the training step. This simply calls
     the underlying estimators's ``fit`` method called and copies over the
@@ -73,6 +75,7 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
     See Also
     --------
     Incremental
+    dask_ml.model_selection.IncrementalSearch
 
     Examples
     --------
@@ -301,6 +304,12 @@ class Incremental(ParallelPostFit):
     train on batches of data. This fits well with Dask's blocked data
     structures.
 
+    .. note::
+
+       This meta-estimator is not appropriate for hyperparameter optimization
+       on larger-than-memory datasets. For that, see
+       :class:dask_ml.model_selection.IncrementalSearch`.
+
     See the `list of incremental learners`_ in the scikit-learn documentation
     for a list of estimators that implement the ``partial_fit`` API. Note that
     `Incremental` is not limited to just these classes, it will work on any
@@ -360,6 +369,7 @@ class Incremental(ParallelPostFit):
     See Also
     --------
     ParallelPostFit
+    dask_ml.model_selection.IncrementalSearch
 
     Examples
     --------

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -143,6 +143,16 @@ class ParallelPostFit(sklearn.base.BaseEstimator):
         copy_learned_attributes(result, self.estimator)
         return self
 
+    def partial_fit(self, X, y=None, **kwargs):
+        logger.info("Starting partial_fit")
+        with _timer("fit", _logger=logger):
+            result = self.estimator.partial_fit(X, y, **kwargs)
+
+        # Copy over learned attributes
+        copy_learned_attributes(result, self)
+        copy_learned_attributes(result, self.estimator)
+        return self
+
     def transform(self, X):
         """Transform block or partition-wise for dask inputs.
 

--- a/docs/source/examples/text-vectorization.ipynb
+++ b/docs/source/examples/text-vectorization.ipynb
@@ -54,9 +54,10 @@
     "        os.mkdir(data_path)\n",
     "\n",
     "        def progress(blocknum, bs, size):\n",
-    "            total_sz_mb = '%.2f MB' % (size / 1e6)\n",
-    "            current_sz_mb = '%.2f MB' % ((blocknum * bs) / 1e6)\n",
-    "            print('\\rdownloaded %s / %s' % (current_sz_mb, total_sz_mb))\n",
+    "            if blocknum % 10 == 0:\n",
+    "                total_sz_mb = '%.2f MB' % (size / 1e6)\n",
+    "                current_sz_mb = '%.2f MB' % ((blocknum * bs) / 1e6)\n",
+    "                print('\\rdownloaded %s / %s' % (current_sz_mb, total_sz_mb))\n",
     "\n",
     "        archive_path = os.path.join(data_path, ARCHIVE_FILENAME)\n",
     "        urlretrieve(DOWNLOAD_URL, filename=archive_path,\n",
@@ -174,7 +175,7 @@
    "source": [
     "import sparse\n",
     "\n",
-    "X.map_blocks(sparse.COO.from_scipy_sparse).compute()"
+    "X.map_blocks(sparse.COO.from_scipy_sparse, dtype=X.dtype).compute()"
    ]
   }
  ],

--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -181,7 +181,7 @@ optimization.
 
 .. autosummary::
    dask_ml.model_selection.RandomizedIncrementalSearch
-   dask_ml.model_selection.SuccessiveReductionSearch
+   dask_ml.model_selection.ExponentialDecaySearch
 
 Broadly speaking, incremental optimization starts with a batch of models (underlying
 estimators and hyperparameter combinationms) and repeatedly calls the underlying estimator's
@@ -192,7 +192,7 @@ they prioritize certain models, and when they determine that they've finished.
 
    These estimators require the optional ``distributed`` library.
 
-Here's an example training on a "large" dataset (a Dask array) with the ``SuccessiveReductionSearch``
+Here's an example training on a "large" dataset (a Dask array) with the ``ExponentialDecaySearch``
 
 .. ipython:: python
 
@@ -219,5 +219,5 @@ The distribution of parameters we'll sample from.
               'l1_ratio': np.linspace(0, 1, num=1000),
               'average': [True, False]}
 
-    search = SuccessiveReductionSearch(model, params, random_state=0)
+    search = ExponentialDecaySearch(model, params, random_state=0)
     search.fit(X, y, classes=[0, 1])

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -17,6 +17,14 @@ Scikit-Learn estimators supporting the ``partial_fit`` API. You wrap the
 underlying estimator in ``Incremental``. Dask-ML will sequentially pass each
 block of a Dask Array to the underlying estimator's ``partial_fit`` method.
 
+.. note::
+
+   :class:`dask_ml.wrappers.Incremetnal` currently does not work well with
+   hyper-parameter optimization like :class:`sklearn.model_selection.GridSearchCV`.
+   If you need to do hyper-parameter optimization on larger-than-memory datasets,
+   we recommend :class:`dask_ml.model_selection.IncrementalSearch`. See
+   :ref:`hyperparameter.incremental` for an introduction.
+
 .. _incremental.blockwise-metaestimator:
 
 Incremental Meta-estimator
@@ -105,18 +113,5 @@ If necessary, the actual estimator trained is available as ``Incremental.estimat
 Incremental Learning and Hyper-parameter Optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:class:`Incremental` is a meta-estimator.
-To search over the hyper-parameters of the underlying estimator, use the usual scikit-learn convention of
-prefixing the parameter name with ``<name>__``. For ``Incremental``, ``name`` is always ``estimator``.
-
-
-.. ipython:: python
-
-   from sklearn.model_selection import GridSearchCV
-
-   param_grid = {'estimator__alpha': [0.10, 10.0]}
-   gs = GridSearchCV(clf, param_grid)
-   gs.fit(X, y, classes=[0, 1])
-
-
-This can be mixed with :ref:`joblib` to use a cluster for training in parallel, even if you're RAM-bound.
+See :ref:`_hyperparameter.incremental` for more on how to do hyperparameter optimization on
+larger than memory datasets.

--- a/docs/source/modules/generted/dask_ml.compose.ColumnTransformer.rst
+++ b/docs/source/modules/generted/dask_ml.compose.ColumnTransformer.rst
@@ -1,0 +1,16 @@
+:mod:`dask_ml.compose`.ColumnTransformer
+===============================================
+
+.. currentmodule:: dask_ml.compose
+
+.. autoclass:: ColumnTransformer
+
+   
+   .. automethod:: __init__
+   
+
+.. include:: dask_ml.compose.ColumnTransformer.examples
+
+.. raw:: html
+
+    <div class="clearer"></div>

--- a/docs/source/modules/generted/dask_ml.compose.make_column_transformer.rst
+++ b/docs/source/modules/generted/dask_ml.compose.make_column_transformer.rst
@@ -1,0 +1,6 @@
+dask\_ml.compose.make\_column\_transformer
+==========================================
+
+.. currentmodule:: dask_ml.compose
+
+.. autofunction:: make_column_transformer

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -1,6 +1,5 @@
 import random
 
-import dask
 import numpy as np
 import toolz
 from dask.distributed import Future

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -18,7 +18,7 @@ from dask_ml.model_selection._incremental import (
 )
 
 
-@gen_cluster(client=True, timeout=None)
+@gen_cluster(client=True, timeout=60)
 def test_basic(c, s, a, b):
     X, y = make_classification(n_samples=1000, n_features=5, chunks=100)
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
@@ -128,7 +128,7 @@ def test_partial_fit_doesnt_mutate_inputs():
     assert new_meta2 != new_meta
 
 
-@gen_cluster(client=True, timeout=None)
+@gen_cluster(client=True, timeout=60)
 def test_explicit(c, s, a, b):
     X, y = make_classification(n_samples=1000, n_features=10, chunks=(200, 10))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -11,7 +11,7 @@ from tornado import gen
 
 from dask_ml.datasets import make_classification
 from dask_ml.model_selection._incremental import (
-    WorstIncrementalSearch,
+    RandomizedWorstIncrementalSearch,
     _partial_fit,
     _score,
     fit,
@@ -194,7 +194,7 @@ def test_incremental_search(loop):  # noqa: F811
 
     params = {"alpha": np.logspace(-2, 10, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-    search = WorstIncrementalSearch(model, params, n_iter=10)
+    search = RandomizedWorstIncrementalSearch(model, params, n_iter=10)
 
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop):

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -282,6 +282,7 @@ def test_numpy_array(c, s, a, b):
     yield search.fit(X, y, classes=[0, 1])
 
 
+@gen_cluster(client=True)
 def test_transform(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = MiniBatchKMeans(random_state=0)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -10,13 +10,11 @@ from sklearn.model_selection import ParameterSampler
 from tornado import gen
 
 from dask_ml.datasets import make_classification
-from dask_ml.model_selection._incremental import (
+from dask_ml.model_selection import (
     RandomizedIncrementalSearch,
     SuccessiveReductionSearch,
-    _partial_fit,
-    _score,
-    fit,
 )
+from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 
 
 @gen_cluster(client=True, timeout=500)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -11,7 +11,7 @@ from tornado import gen
 
 from dask_ml.datasets import make_classification
 from dask_ml.model_selection._incremental import (
-    RandomIncrementalSearch,
+    RandomizedIncrementalSearch,
     SuccessiveReductionSearch,
     _partial_fit,
     _score,
@@ -189,7 +189,9 @@ def test_explicit(c, s, a, b):
         yield gen.sleep(0.01)
 
 
-@pytest.mark.parametrize("Search", [RandomIncrementalSearch, SuccessiveReductionSearch])
+@pytest.mark.parametrize(
+    "Search", [RandomizedIncrementalSearch, SuccessiveReductionSearch]
+)
 def test_BaseIncrementalSearch(Search):
     @gen_cluster(client=True)
     def test_search(c, s, a, b):

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -18,7 +18,7 @@ from dask_ml.model_selection._incremental import (
 )
 
 
-@gen_cluster(client=True, timeout=60)
+@gen_cluster(client=True, timeout=500)
 def test_basic(c, s, a, b):
     X, y = make_classification(n_samples=1000, n_features=5, chunks=100)
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
@@ -128,7 +128,7 @@ def test_partial_fit_doesnt_mutate_inputs():
     assert new_meta2 != new_meta
 
 
-@gen_cluster(client=True, timeout=60)
+@gen_cluster(client=True, timeout=500)
 def test_explicit(c, s, a, b):
     X, y = make_classification(n_samples=1000, n_features=10, chunks=(200, 10))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -291,4 +291,4 @@ def test_transform(c, s, a, b):
     yield search.fit(X, y)
     X_, = yield c.compute([X])
     result = search.transform(X_)
-    assert result.shape == (100, 5)
+    assert result.shape == (100, search.best_estimator_.n_clusters)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -200,4 +200,5 @@ def test_RandomIncrementalSearch(c, s, a, b):
 
     assert search.history_results_
     assert isinstance(search.best_estimator_, SGDClassifier)
+    assert search.best_score_ > 0
     assert "visualize" not in search.__dict__

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import ParameterGrid, ParameterSampler
 from tornado import gen
 
 from dask_ml.datasets import make_classification
-from dask_ml.model_selection import ExponentialDecaySearch, RandomizedIncrementalSearch
+from dask_ml.model_selection import IncrementalSearch
 from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 
 
@@ -187,69 +187,51 @@ def test_explicit(c, s, a, b):
         yield gen.sleep(0.01)
 
 
-@pytest.mark.parametrize(
-    "Search", [RandomizedIncrementalSearch, ExponentialDecaySearch]
-)
-def test_BaseIncrementalSearch(Search):
-    @gen_cluster(client=True)
-    def test_search(c, s, a, b):
-        X, y = make_classification(n_samples=1000, n_features=5, chunks=(100, 5))
-        model = SGDClassifier(tol=1e-3, penalty="elasticnet")
+@gen_cluster(client=True)
+def test_search(c, s, a, b):
+    X, y = make_classification(n_samples=1000, n_features=5, chunks=(100, 5))
+    model = SGDClassifier(tol=1e-3, penalty="elasticnet")
 
-        params = {
-            "alpha": np.logspace(-2, 10, 100),
-            "l1_ratio": np.linspace(0.01, 1, 200),
-        }
+    params = {"alpha": np.logspace(-2, 10, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-        search = Search(model, params, n_initial_parameters=10, max_iter=10)
-        yield search.fit(X, y, classes=[0, 1])
+    search = IncrementalSearch(model, params, n_initial_parameters=10, max_iter=10)
+    yield search.fit(X, y, classes=[0, 1])
 
-        assert search.history_results_
-        for d in search.history_results_:
-            assert d["partial_fit_calls"] <= search.max_iter + 1
-        assert isinstance(search.best_estimator_, SGDClassifier)
-        assert search.best_score_ > 0
-        assert "visualize" not in search.__dict__
-        assert search.best_params_
-
-    test_search()
+    assert search.history_results_
+    for d in search.history_results_:
+        assert d["partial_fit_calls"] <= search.max_iter + 1
+    assert isinstance(search.best_estimator_, SGDClassifier)
+    assert search.best_score_ > 0
+    assert "visualize" not in search.__dict__
+    assert search.best_params_
 
 
-@pytest.mark.parametrize(
-    "Search", [RandomizedIncrementalSearch, ExponentialDecaySearch]
-)
-def test_patience(Search):
-    @gen_cluster(client=True)
-    def test_search(c, s, a, b):
-        X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+@gen_cluster(client=True)
+def test_search_2(c, s, a, b):
+    X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
 
-        class ConstantClassifier(SGDClassifier):
-            def score(*args, **kwargs):
-                return 0.5
+    class ConstantClassifier(SGDClassifier):
+        def score(*args, **kwargs):
+            return 0.5
 
-        model = ConstantClassifier(tol=1e-3)
+    model = ConstantClassifier(tol=1e-3)
 
-        params = {
-            "alpha": np.logspace(-2, 10, 100),
-            "l1_ratio": np.linspace(0.01, 1, 200),
-        }
+    params = {"alpha": np.logspace(-2, 10, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-        search = Search(model, params, n_initial_parameters=10, patience=2)
-        yield search.fit(X, y, classes=[0, 1])
+    search = IncrementalSearch(model, params, n_initial_parameters=10, patience=2)
+    yield search.fit(X, y, classes=[0, 1])
 
-        assert search.history_results_
-        for d in search.history_results_:
-            assert d["partial_fit_calls"] <= 3
-        assert isinstance(search.best_estimator_, SGDClassifier)
-        assert search.best_score_ > 0
-        assert "visualize" not in search.__dict__
+    assert search.history_results_
+    for d in search.history_results_:
+        assert d["partial_fit_calls"] <= 3
+    assert isinstance(search.best_estimator_, SGDClassifier)
+    assert search.best_score_ > 0
+    assert "visualize" not in search.__dict__
 
-        X_test, y_test = yield c.compute([X, y])
+    X_test, y_test = yield c.compute([X, y])
 
-        search.predict(X_test)
-        search.score(X_test, y_test)
-
-    test_search()
+    search.predict(X_test)
+    search.score(X_test, y_test)
 
 
 @gen_cluster(client=True)
@@ -260,7 +242,7 @@ def test_gridsearch(c, s, a, b):
 
     params = {"alpha": np.logspace(-2, 10, 3), "l1_ratio": np.linspace(0.01, 1, 2)}
 
-    search = ExponentialDecaySearch(model, params, n_initial_parameters="grid")
+    search = IncrementalSearch(model, params, n_initial_parameters="grid")
     yield search.fit(X, y, classes=[0, 1])
 
     assert {frozenset(d["params"].items()) for d in search.history_results_} == {

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import toolz
 from dask.distributed import Future
-from distributed import Client
 from distributed.utils_test import cluster, gen_cluster, loop  # noqa: F401
 from sklearn.linear_model import SGDClassifier
 from sklearn.model_selection import ParameterSampler
@@ -207,7 +206,7 @@ def test_BaseIncrementalSearch(Search):
 
         assert search.history_results_
         assert isinstance(search.best_estimator_, SGDClassifier)
-        # assert search.best_score_ > 0
+        assert search.best_score_ > 0
         assert "visualize" not in search.__dict__
 
     test_search()

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -201,7 +201,7 @@ def test_BaseIncrementalSearch(Search):
             "l1_ratio": np.linspace(0.01, 1, 200),
         }
 
-        search = Search(model, params, n_iter=10)
+        search = Search(model, params, n_initial_parameters=10)
         yield search.fit(X, y, classes=[0, 1])
 
         assert search.history_results_

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -1,7 +1,6 @@
 import random
 
 import numpy as np
-import pytest
 import toolz
 from dask.distributed import Future
 from distributed.utils_test import cluster, gen_cluster, loop  # noqa: F401

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -205,8 +205,8 @@ def test_search(c, s, a, b):
     assert search.best_params_
 
 
-@gen_cluster(client=True)
-def test_search_2(c, s, a, b):
+@gen_cluster(client=True, timeout=None)
+def test_search_patience(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
 
     class ConstantClassifier(SGDClassifier):

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -11,7 +11,7 @@ from tornado import gen
 
 from dask_ml.datasets import make_classification
 from dask_ml.model_selection._incremental import (
-    IncrementalRandomizedSearchCV,
+    WorstIncrementalSearch,
     _partial_fit,
     _score,
     fit,
@@ -194,12 +194,12 @@ def test_incremental_search(loop):  # noqa: F811
 
     params = {"alpha": np.logspace(-2, 10, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-    search = IncrementalRandomizedSearchCV(model, params, n_iter=10)
+    search = WorstIncrementalSearch(model, params, n_iter=10)
 
     with cluster() as (s, [a, b]):
         with Client(s["address"], loop=loop):
             search.fit(X, y, classes=[0, 1])
 
-    assert search.cv_results_
+    assert search.history_results_
     assert search.best_estimator_
     assert "visualize" not in search.__dict__

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -204,10 +204,12 @@ def test_BaseIncrementalSearch(Search):
             "l1_ratio": np.linspace(0.01, 1, 200),
         }
 
-        search = Search(model, params, n_initial_parameters=10)
+        search = Search(model, params, n_initial_parameters=10, max_iter=10)
         yield search.fit(X, y, classes=[0, 1])
 
         assert search.history_results_
+        for d in search.history_results_:
+            assert d['partial_fit_calls'] <= search.max_iter + 1
         assert isinstance(search.best_estimator_, SGDClassifier)
         assert search.best_score_ > 0
         assert "visualize" not in search.__dict__

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -12,7 +12,7 @@ from tornado import gen
 from dask_ml.datasets import make_classification
 from dask_ml.model_selection import (
     RandomizedIncrementalSearch,
-    SuccessiveReductionSearch,
+    ExponentialDecaySearch,
 )
 from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 
@@ -191,7 +191,7 @@ def test_explicit(c, s, a, b):
 
 
 @pytest.mark.parametrize(
-    "Search", [RandomizedIncrementalSearch, SuccessiveReductionSearch]
+    "Search", [RandomizedIncrementalSearch, ExponentialDecaySearch]
 )
 def test_BaseIncrementalSearch(Search):
     @gen_cluster(client=True)
@@ -216,7 +216,7 @@ def test_BaseIncrementalSearch(Search):
 
 
 @pytest.mark.parametrize(
-    "Search", [RandomizedIncrementalSearch, SuccessiveReductionSearch]
+    "Search", [RandomizedIncrementalSearch, ExponentialDecaySearch]
 )
 def test_patience(Search):
     @gen_cluster(client=True)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -23,7 +23,7 @@ def test_basic(c, s, a, b):
     X, y = make_classification(n_samples=1000, n_features=5, chunks=100)
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
 
-    params = {"alpha": np.logspace(-2, 1, num=4), "l1_ratio": [0.01, 1.0]}
+    params = {"alpha": np.logspace(-2, 1, num=50), "l1_ratio": [0.01, 1.0]}
 
     X_test, y_test = X[:100], y[:100]
     X_train = X[100:]

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -234,6 +234,18 @@ def test_search_2(c, s, a, b):
 
 
 @gen_cluster(client=True)
+def test_search_max_iter(c, s, a, b):
+    X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+    model = SGDClassifier(tol=1e-3, penalty="elasticnet")
+    params = {"alpha": np.logspace(-2, 10, 10), "l1_ratio": np.linspace(0.01, 1, 20)}
+
+    search = IncrementalSearch(model, params, n_initial_parameters=10, max_iter=1)
+    yield search.fit(X, y, classes=[0, 1])
+    for d in search.history_results_:
+        assert d["partial_fit_calls"] <= 1
+
+
+@gen_cluster(client=True)
 def test_gridsearch(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
 

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -222,9 +222,11 @@ def test_patience(Search):
     @gen_cluster(client=True)
     def test_search(c, s, a, b):
         X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+
         class ConstantClassifier(SGDClassifier):
             def score(*args, **kwargs):
                 return 0.5
+
         model = ConstantClassifier(tol=1e-3)
 
         params = {

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -202,3 +202,4 @@ def test_incremental_search(loop):  # noqa: F811
 
     assert search.cv_results_
     assert search.best_estimator_
+    assert "visualize" not in search.__dict__

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -28,12 +28,15 @@ def test_basic(c, s, a, b):
     X_train = X[100:]
     y_train = y[100:]
 
-    n_parameters = 50
+    n_parameters = 5
     param_list = list(ParameterSampler(params, n_parameters))
 
     def additional_calls(info):
         pf_calls = {k: v[-1]["partial_fit_calls"] for k, v in info.items()}
         ret = {k: int(calls < 10) for k, calls in pf_calls.items()}
+        if len(ret) == 1:
+            return {list(ret)[0]: 0}
+
         # Don't train one model
         some_keys = set(ret.keys()) - {0}
         del ret[random.choice(list(some_keys))]
@@ -76,7 +79,7 @@ def test_basic(c, s, a, b):
 
     groups = toolz.groupby("partial_fit_calls", history)
     assert len(groups[1]) > len(groups[2]) > len(groups[3]) > len(groups[max(groups)])
-    assert max(groups) == 10
+    assert max(groups) == n_parameters
 
     keys = list(models.keys())
     for key in keys:


### PR DESCRIPTION
Here's a rough draft of what a base class calling `_incremental.fit` may look like. I've just been stealing pieces from https://github.com/dask/dask-ml/pull/221 and making it work for the random sampler with the `remove_worst` strategy.

Looking at #221 there were a few pieces that will be common to each subclass

* data checking
* CV splitting
* building cv_results (partly)
* selecting the best model (partly)

That leaves a few things that must be done by each class

* Building the dict of `{model_id: (param_list, additional_calls)}`
* transforming the output of `fit` on each of those into a common form

In the end, I'm not sure how much code reuse we'll actually get, but I think it's worth exploring a bit further. A next step would be to make a branch of #221 that builds on top of this, and see how well the hyperband structure maps on to this base class. From there we can decide whether the base class can be adjusted to fit hyperband's needs, or whether it should just be scrapped. I'll try to get to that today.

cc @stsievert 