### PR TITLE
IncrementalSearch edge cases

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -772,13 +772,18 @@ class IncrementalSearch(BaseIncrementalSearch):
 
         current_time_step = time_step + 1
         next_time_step = current_time_step
+
+        if inverse(current_time_step) == 0:
+            # we'll never get out of here
+            next_time_step = 1
+
         while inverse(current_time_step) == inverse(next_time_step) and (
             not self.patience
             or next_time_step - current_time_step < self.scores_per_fit
         ):
             next_time_step += 1
 
-        target = inverse(next_time_step)
+        target = max(1, inverse(next_time_step))
         best = toolz.topk(target, info, key=lambda k: info[k][-1]["score"])
 
         if len(best) == 1:

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -530,7 +530,6 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
             random_state=self.random_state,
         )
         results = self._process_results(results)
-        self.results_ = results
         history_results = self._get_history_results(results)
         best_estimator, best_index = self._get_best(results, history_results)
         best_estimator = yield best_estimator
@@ -773,17 +772,13 @@ class IncrementalSearch(BaseIncrementalSearch):
 
         current_time_step = time_step + 1
         next_time_step = current_time_step
-        if inverse(current_time_step) == 0:
-            # we'll never get out of here
-            next_time_step = 1
-        else:
-            while inverse(current_time_step) == inverse(next_time_step) and (
-                not self.patience
-                or next_time_step - current_time_step < self.scores_per_fit
-            ):
-                next_time_step += 1
+        while inverse(current_time_step) == inverse(next_time_step) and (
+            not self.patience
+            or next_time_step - current_time_step < self.scores_per_fit
+        ):
+            next_time_step += 1
 
-        target = max(1, inverse(next_time_step))
+        target = inverse(next_time_step)
         best = toolz.topk(target, info, key=lambda k: info[k][-1]["score"])
 
         if len(best) == 1:

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -530,6 +530,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
             random_state=self.random_state,
         )
         results = self._process_results(results)
+        self.results_ = results
         history_results = self._get_history_results(results)
         best_estimator, best_index = self._get_best(results, history_results)
         best_estimator = yield best_estimator
@@ -772,13 +773,17 @@ class IncrementalSearch(BaseIncrementalSearch):
 
         current_time_step = time_step + 1
         next_time_step = current_time_step
-        while inverse(current_time_step) == inverse(next_time_step) and (
-            not self.patience
-            or next_time_step - current_time_step < self.scores_per_fit
-        ):
-            next_time_step += 1
+        if inverse(current_time_step) == 0:
+            # we'll never get out of here
+            next_time_step = 1
+        else:
+            while inverse(current_time_step) == inverse(next_time_step) and (
+                not self.patience
+                or next_time_step - current_time_step < self.scores_per_fit
+            ):
+                next_time_step += 1
 
-        target = inverse(next_time_step)
+        target = max(1, inverse(next_time_step))
         best = toolz.topk(target, info, key=lambda k: info[k][-1]["score"])
 
         if len(best) == 1:

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -291,3 +291,26 @@ def test_transform(c, s, a, b):
     X_, = yield c.compute([X])
     result = search.transform(X_)
     assert result.shape == (100, search.best_estimator_.n_clusters)
+
+
+@gen_cluster(client=True)
+def test_small(c, s, a, b):
+    X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+    model = SGDClassifier(tol=1e-3, penalty="elasticnet")
+    params = {"alpha": [0.1, 0.5, 0.75, 1.0]}
+    search = IncrementalSearch(model, params, n_initial_parameters="grid")
+    yield search.fit(X, y, classes=[0, 1])
+    X_, = yield c.compute([X])
+    search.predict(X_)
+
+
+@gen_cluster(client=True)
+def test_smaller(c, s, a, b):
+    # infininte loop
+    X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+    model = SGDClassifier(tol=1e-3, penalty="elasticnet")
+    params = {"alpha": [0.1, 0.5]}
+    search = IncrementalSearch(model, params, n_initial_parameters="grid")
+    yield search.fit(X, y, classes=[0, 1])
+    X_, = yield c.compute([X])
+    search.predict(X_)


### PR DESCRIPTION
A couple issues when given a small grid.

For the first, we decided that training 0 models was best, as `inverse(next_time_step)` was 0.

For the second, we got stuck in an infinite `while True` loop since

1. `inverse(current_time_step) == inverse(next_time_step)` was always equal (both were 0), and
2. next_time_step is increasing.

We could detect this and raise when something like `start < current_time_step + 1`, but ideally we would support this. I'm not sure that my fix is correct though.