### PR TITLE
Adds sklearn version check for ColumnTransformer import

### DIFF
--- a/dask_ml/compose/__init__.py
+++ b/dask_ml/compose/__init__.py
@@ -2,6 +2,15 @@
 
 These estimators are useful for working with heterogenous tabular data.
 """
-from ._column_transformer import ColumnTransformer, make_column_transformer
+from .._compat import SK_VERSION
+from packaging.version import parse
 
-__all__ = ["ColumnTransformer", "make_column_transformer"]
+__all__ = []
+
+if SK_VERSION >= parse("0.20.0.dev0"):
+    from ._column_transformer import ColumnTransformer, make_column_transformer  # noqa
+
+    __all__.extend(["ColumnTransformer", "make_column_transformer"])
+
+del SK_VERSION
+del parse

--- a/dask_ml/compose/_column_transformer.py
+++ b/dask_ml/compose/_column_transformer.py
@@ -2,8 +2,8 @@ import dask.array as da
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from scipy import sparse
 from packaging import version
+from scipy import sparse
 
 from .._compat import SK_VERSION
 

--- a/dask_ml/compose/_column_transformer.py
+++ b/dask_ml/compose/_column_transformer.py
@@ -23,6 +23,10 @@ class ColumnTransformer(sklearn.compose.ColumnTransformer):
 
     .. versionadded:: 0.9.0
 
+    .. note::
+
+       This requires scikit-learn 0.20.0 or newer.
+
     Parameters
     ----------
     transformers : list of tuples

--- a/dask_ml/compose/_column_transformer.py
+++ b/dask_ml/compose/_column_transformer.py
@@ -2,9 +2,16 @@ import dask.array as da
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import sklearn.compose
 from scipy import sparse
-from sklearn.compose._column_transformer import _get_transformer_list
+from packaging import version
+
+from .._compat import SK_VERSION
+
+if SK_VERSION >= version.Version("0.20.0dev0"):
+    import sklearn.compose
+    from sklearn.compose._column_transformer import _get_transformer_list
+else:
+    raise ImportError("scikit-learn >= 0.20 required from ColumnTransformer")
 
 
 class ColumnTransformer(sklearn.compose.ColumnTransformer):


### PR DESCRIPTION
This PR adds a scikit-learn version check to only add `ColumnTransformer` to the `dask_ml.compose` namespace if `ColumnTransformer` is present in `sklearn` (i.e. `sklearn` version >= `0.20.0.dev0`). 

For example, currently `dask_ml` will still attempt to import `ColumnTransformer` when using v0.19.1 of scikit-learn: 

```python
In [1]: import sklearn

In [2]: sklearn.__version__
Out[2]: '0.19.1'

In [3]: from dask_ml.compose import ColumnTransformer
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-3-037f94f5147b> in <module>()
----> 1 from dask_ml.compose import ColumnTransformer

~/github/dask/dask-ml/dask_ml/compose/__init__.py in <module>()
     16 # del parse
     17
---> 18 from ._column_transformer import ColumnTransformer, make_column_transformer
     19
     20 __all__ = ["ColumnTransformer", "make_column_transformer"]

~/github/dask/dask-ml/dask_ml/compose/_column_transformer.py in <module>()
      3 import numpy as np
      4 import pandas as pd
----> 5 import sklearn.compose
      6 from scipy import sparse
      7 from sklearn.compose._column_transformer import _get_transformer_list

ModuleNotFoundError: No module named 'sklearn.compose'
```

This `sklearn` version check is similar to what's done for `OneHotEncoder` in `dask_ml/preprocessing/__init__.py`

https://github.com/dask/dask-ml/blob/b5b6954cbd8a4da89aa4da9612e970a0680290da/dask_ml/preprocessing/__init__.py#L30-L33