### PR TITLE
Added DeprecationDict

### DIFF
--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -54,7 +54,7 @@ from .methods import (
     pipeline,
     score,
 )
-from .utils import is_dask_collection, to_indexable, to_keys, unzip
+from .utils import DeprecationDict, is_dask_collection, to_indexable, to_keys, unzip
 
 try:
     from cytoolz import get, pluck
@@ -66,7 +66,6 @@ __all__ = ["GridSearchCV", "RandomizedSearchCV"]
 
 
 if SK_VERSION >= packaging.version.parse("0.19.1"):
-    from sklearn.utils.deprecation import DeprecationDict
 
     _RETURN_TRAIN_SCORE_DEFAULT = "warn"
 


### PR DESCRIPTION
This PR adds `DeprecationDict`, which was removed from scikit-learn, to `dask_ml/model_selection/utils.py`. Moving `DeprecationDict` over to `dask_ml` seems reasonable to be, but I'm open to suggestions if other have them. 

Closes  #383