### PR TITLE
Support dataframes in _partial.py::fit/predict

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -162,11 +162,11 @@ def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None, **kwa
     >>> da.learn.predict(sgd, z)  # doctest: +SKIP
     dask.array<x_11, shape=(400,), chunks=((100, 100, 100, 100),), dtype=int64>
     """
-    if not hasattr(x, 'chunks') and hasattr(x, 'to_dask_array'):
+    if not hasattr(x, "chunks") and hasattr(x, "to_dask_array"):
         x = x.to_dask_array()
     assert x.ndim == 2
     if y is not None:
-        if not hasattr(y, 'chunks') and hasattr(y, 'to_dask_array'):
+        if not hasattr(y, "chunks") and hasattr(y, "to_dask_array"):
             y = y.to_dask_array()
         assert y.ndim == 1
         assert x.chunks[0] == y.chunks[0]
@@ -218,7 +218,7 @@ def predict(model, x):
 
     See docstring for ``da.learn.fit``
     """
-    if not hasattr(x, 'chunks') and hasattr(x, 'to_dask_array'):
+    if not hasattr(x, "chunks") and hasattr(x, "to_dask_array"):
         index = x.index
         x = x.to_dask_array()
     else:

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -230,8 +230,6 @@ def predict(model, x):
     xx = np.zeros((1, x.shape[1]), dtype=x.dtype)
     dt = model.predict(xx).dtype
     result = x.map_blocks(func, chunks=(x.chunks[0], (1,)), dtype=dt).squeeze()
-    if index is not None:
-        result = dd.from_dask_array(result, index=index)
     return result
 
 

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -6,7 +6,6 @@ import warnings
 from abc import ABCMeta
 
 import dask
-import dask.dataframe as dd
 import numpy as np
 import six
 import sklearn.utils

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -219,18 +219,14 @@ def predict(model, x):
     See docstring for ``da.learn.fit``
     """
     if not hasattr(x, "chunks") and hasattr(x, "to_dask_array"):
-        index = x.index
         x = x.to_dask_array()
-    else:
-        index = None
     assert x.ndim == 2
     if len(x.chunks[1]) > 1:
         x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
     func = partial(_predict, model)
     xx = np.zeros((1, x.shape[1]), dtype=x.dtype)
     dt = model.predict(xx).dtype
-    result = x.map_blocks(func, chunks=(x.chunks[0], (1,)), dtype=dt).squeeze()
-    return result
+    return x.map_blocks(func, chunks=(x.chunks[0], (1,)), dtype=dt).squeeze()
 
 
 def _copy_partial_doc(cls):

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -87,6 +87,5 @@ def test_dataframes():
 
         sol = sgd.predict(df[["x"]])
         result = predict(sgd, ddf[["x"]])
-        assert isinstance(result, dd.Series)
 
-        da.utils.assert_eq(sol, result.to_dask_array())
+        da.utils.assert_eq(sol, result)

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -4,7 +4,6 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
@@ -78,16 +77,16 @@ def test_fit_shuffle_blocks():
 
 
 def test_dataframes():
-    df = pd.DataFrame({'x': range(10), 'y': [0, 1] * 5})
+    df = pd.DataFrame({"x": range(10), "y": [0, 1] * 5})
     ddf = dd.from_pandas(df, npartitions=2)
 
     with dask.config.set(scheduler="single-threaded"):
         sgd = SGDClassifier(max_iter=5)
 
-        sgd = fit(sgd, ddf[['x']], ddf.y, classes=[0, 1])
+        sgd = fit(sgd, ddf[["x"]], ddf.y, classes=[0, 1])
 
-        sol = sgd.predict(df[['x']])
-        result = predict(sgd, ddf[['x']])
+        sol = sgd.predict(df[["x"]])
+        result = predict(sgd, ddf[["x"]])
         assert isinstance(result, dd.Series)
 
         da.utils.assert_eq(sol, result.to_dask_array())

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -1,7 +1,10 @@
 import dask
 import dask.array as da
+import dask.dataframe as dd
 import numpy as np
+import pandas as pd
 import pytest
+
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier
 
@@ -72,3 +75,19 @@ def test_fit_shuffle_blocks():
             shuffle_blocks=True,
             random_state=da.random.RandomState(42),
         )
+
+
+def test_dataframes():
+    df = pd.DataFrame({'x': range(10), 'y': [0, 1] * 5})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    with dask.config.set(scheduler="single-threaded"):
+        sgd = SGDClassifier(max_iter=5)
+
+        sgd = fit(sgd, ddf[['x']], ddf.y, classes=[0, 1])
+
+        sol = sgd.predict(df[['x']])
+        result = predict(sgd, ddf[['x']])
+        assert isinstance(result, dd.Series)
+
+        da.utils.assert_eq(sol, result.to_dask_array())


### PR DESCRIPTION
Previously these functions would fail on dask dataframes.
Now they coerce to dask arrays, and predict also converts back

I'm not sure if this logic is also handled elsewhere.  I was running into it with the criteo example though.