### PR TITLE
Don't use auto chunking with unknown chunk sizes

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -139,7 +139,10 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
         if isinstance(X, da.Array):
             if X.ndim == 2 and X.numblocks[1] > 1:
                 logger.debug("auto-rechunking 'X'")
-                X = X.rechunk({0: "auto", 1: -1})
+                if not np.isnan(X.chunks[0]).any():
+                    X = X.rechunk({0: "auto", 1: -1})
+                else:
+                    X = X.rechunk({1: -1})
         return X
 
     @property

--- a/tests/test_parallel_post_fit.py
+++ b/tests/test_parallel_post_fit.py
@@ -1,6 +1,7 @@
 import dask
 import dask.array as da
 import dask.dataframe as dd
+import numpy as np
 import pytest
 import sklearn.datasets
 from sklearn.decomposition import PCA
@@ -119,3 +120,8 @@ def test_auto_rechunk():
     assert clf.predict(X).compute().shape == (1000,)
     assert clf.predict_proba(X).compute().shape == (1000, 2)
     assert clf.score(X, y) == clf.score(X.compute(), y.compute())
+
+    X, y = make_classification(n_samples=1000, n_features=20, chunks=100)
+    X = X.rechunk({0: 100, 1: 10})
+    X._chunks = (tuple(np.nan for _ in X.chunks[0]), X.chunks[1])
+    clf.predict(X)


### PR DESCRIPTION
This still needs a test.  I tried modifying `tests/test_parallel_post_fit.py::test_auto_rechunk` but that didn't trigger the failure.  

```diff
diff --git a/tests/test_parallel_post_fit.py b/tests/test_parallel_post_fit.py
index e3e7096..2d3d079 100644
--- a/tests/test_parallel_post_fit.py
+++ b/tests/test_parallel_post_fit.py
@@ -1,6 +1,7 @@
 import dask
 import dask.array as da
 import dask.dataframe as dd
+import numpy as np
 import pytest
 import sklearn.datasets
 from sklearn.decomposition import PCA
@@ -119,3 +120,8 @@ def test_auto_rechunk():
     assert clf.predict(X).compute().shape == (1000,)
     assert clf.predict_proba(X).compute().shape == (1000, 2)
     assert clf.score(X, y) == clf.score(X.compute(), y.compute())
+
+    X, y = make_classification(n_samples=1000, n_features=20, chunks=100)
+    X = X.rechunk({0: 100, 1: 10})
+    X._chunks = (tuple(np.nan for _ in X.chunks[0]), X.chunks[1])
+    clf.fit(X, y)
```

Any suggestions on where this code might trigger @TomAugspurger ?