### PR TITLE
Allow compute=False in ParallelPostFit.score

### DIFF
--- a/dask_ml/metrics/scorer.py
+++ b/dask_ml/metrics/scorer.py
@@ -1,3 +1,4 @@
+import functools
 import six
 from sklearn.metrics import make_scorer
 from sklearn.metrics.scorer import check_scoring as sklearn_check_scoring
@@ -5,10 +6,10 @@ from sklearn.metrics.scorer import check_scoring as sklearn_check_scoring
 from . import accuracy_score, log_loss, mean_squared_error, r2_score
 
 # Scorers
-accuracy_scorer = make_scorer(accuracy_score)
-neg_mean_squared_error_scorer = make_scorer(mean_squared_error, greater_is_better=False)
-r2_scorer = make_scorer(r2_score)
-neg_log_loss_scorer = make_scorer(log_loss, greater_is_better=False, needs_proba=True)
+accuracy_scorer = (accuracy_score, {})
+neg_mean_squared_error_scorer = (mean_squared_error, dict(greater_is_better=False))
+r2_scorer = (r2_score, {})
+neg_log_loss_scorer = (log_loss, dict(greater_is_better=False, needs_proba=True))
 
 
 SCORERS = dict(
@@ -36,7 +37,7 @@ def get_scorer(scoring, compute=True):
     # and don't have back-compat code
     if isinstance(scoring, six.string_types):
         try:
-            scorer = SCORERS[scoring]
+            scorer, kwargs = SCORERS[scoring]
         except KeyError:
             raise ValueError(
                 "{} is not a valid scoring value. "
@@ -44,8 +45,11 @@ def get_scorer(scoring, compute=True):
             )
     else:
         scorer = scoring
+        kwargs = {}
 
-    return scorer
+    kwargs['compute'] = compute
+
+    return make_scorer(scorer, **kwargs)
 
 
 def check_scoring(estimator, scoring=None, **kwargs):

--- a/dask_ml/metrics/scorer.py
+++ b/dask_ml/metrics/scorer.py
@@ -1,4 +1,3 @@
-import functools
 import six
 from sklearn.metrics import make_scorer
 from sklearn.metrics.scorer import check_scoring as sklearn_check_scoring
@@ -47,7 +46,7 @@ def get_scorer(scoring, compute=True):
         scorer = scoring
         kwargs = {}
 
-    kwargs['compute'] = compute
+    kwargs["compute"] = compute
 
     return make_scorer(scorer, **kwargs)
 
@@ -71,5 +70,6 @@ def check_scoring(estimator, scoring=None, **kwargs):
                 "to a scorer." % scoring
             )
     if scoring in SCORERS.keys():
-        return SCORERS[scoring]
+        func, kwargs = SCORERS[scoring]
+        return make_scorer(func, **kwargs)
     return res

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -207,7 +207,7 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
         else:
             return transform(X)
 
-    def score(self, X, y):
+    def score(self, X, y, compute=True):
         """Returns the score on the given data.
 
         Parameters
@@ -244,7 +244,7 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
             if not dask.is_dask_collection(X) and not dask.is_dask_collection(y):
                 scorer = sklearn.metrics.get_scorer(scoring)
             else:
-                scorer = get_scorer(scoring)
+                scorer = get_scorer(scoring, compute=compute)
             return scorer(self, X, y)
         else:
             return self._postfit_estimator.score(X, y)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -97,10 +97,6 @@ def test_scoring_string(scheduler, xy_classification, scoring):
     X, y = xy_classification
     with scheduler() as (s, [a, b]):
         clf = Incremental(SGDClassifier(tol=1e-3), scoring=scoring)
-        if scoring:
-            assert dask_ml.metrics.scorer.SCORERS[scoring] == check_scoring(
-                clf, scoring=scoring
-            )
         assert callable(check_scoring(clf, scoring=scoring))
         clf.fit(X, y, classes=np.unique(y))
         clf.score(X, y)
@@ -167,4 +163,4 @@ def test_replace_scoring(estimator, fit_kwargs, scoring, xy_classification, mock
         inc.score(X, y)
 
     assert patch.call_count == 1
-    patch.assert_called_with(scoring)
+    patch.assert_called_with(scoring, compute=True)

--- a/tests/test_parallel_post_fit.py
+++ b/tests/test_parallel_post_fit.py
@@ -37,6 +37,16 @@ def test_no_method_raises():
     assert m.match("The wrapped estimator (.|\n)* 'predict_proba' method.")
 
 
+def test_laziness():
+    clf = ParallelPostFit(LinearRegression())
+    X, y = make_classification(chunks=50)
+    clf.fit(X, y)
+
+    x = clf.score(X, y, compute=False)
+    assert dask.is_dask_collection(x)
+    assert 0 < x.compute() < 1
+
+
 @pytest.mark.parametrize("kind", ["numpy", "dask.dataframe", "dask.array"])
 def test_predict(kind):
     X, y = make_classification(chunks=100)


### PR DESCRIPTION
I notice that we are not consistent in the various `score` methods in our classes.  Some of them are lazy, some of them are immediate.  None of them support a `compute=` keyword. 

All of the others are trivial to add a `compute=` keyword, what should the default be?  True or False?

