### PR TITLE
API: improve and clean IncrementalSearch API

### DIFF
--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -19,8 +19,8 @@ __all__ = [
 
 
 try:
-    from ._incremental import IncrementalSearch  # noqa: F401
+    from ._incremental import IncrementalSearchCV  # noqa: F401
 
-    __all__.extend(["IncrementalSearch"])
+    __all__.extend(["IncrementalSearchCV"])
 except ImportError:
     pass

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -258,8 +258,8 @@ def _fit(
 
     models = {k: client.submit(operator.getitem, v, 0) for k, v in models.items()}
     yield wait(models)
-
-    best = max(scores.items(), key=operator.itemgetter(1))
+    scores = yield client.gather(scores)
+    best = max(scores.items(), key=lambda x: x[1]["score"])
 
     info = defaultdict(list)
     for h in history:

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -8,6 +8,7 @@ from time import time
 import dask
 import dask.array as da
 import numpy as np
+import scipy.stats
 import toolz
 from dask.distributed import Future, default_client, futures_of, wait
 from distributed.utils import log_errors
@@ -495,9 +496,9 @@ class BaseIncrementalSearchCV(BaseEstimator, MetaEstimatorMixin):
             }
         )
         cv_results = {k: np.array(v) for k, v in cv_results.items()}
-
-        order = (-1 * cv_results["test_score"]).argsort()
-        cv_results["rank_test_score"] = order.argsort() + 1
+        cv_results["rank_test_score"] = scipy.stats.rankdata(
+            -cv_results["test_score"], method="min"
+        ).astype(int)
         return cv_results
 
     def _get_best(self, results, cv_results):

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -396,7 +396,7 @@ def fit(
 # ----------------------------------------------------------------------------
 
 
-class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
+class BaseIncrementalSearchCV(BaseEstimator, MetaEstimatorMixin):
     """Base class for estimators using the incremental `fit`.
 
     Subclasses must implement the following abstract method
@@ -599,7 +599,7 @@ class BaseIncrementalSearch(BaseEstimator, MetaEstimatorMixin):
         return self.scorer_(self.best_estimator_, X, y)
 
 
-class IncrementalSearch(BaseIncrementalSearch):
+class IncrementalSearchCV(BaseIncrementalSearchCV):
     """
     Incrementally search for hyper-parameters on models that support partial_fit
 
@@ -715,16 +715,16 @@ class IncrementalSearch(BaseIncrementalSearch):
     ...           'l1_ratio': np.linspace(0, 1, num=1000),
     ...           'average': [True, False]}
 
-    >>> search = IncrementalSearch(model, params, random_state=0)
+    >>> search = IncrementalSearchCV(model, params, random_state=0)
     >>> search.fit(X, y, classes=[0, 1])
-    IncrementalSearch(...)
+    IncrementalSearchCV(...)
 
     Alternatively you can provide keywords to start with more hyper-parameters,
     but stop those that don't seem to improve with more data.
 
-    >>> search = IncrementalSearch(model, params, random_state=0,
-    ...                            n_initial_parameters=1000,
-    ...                            patience=20, max_iter=100)
+    >>> search = IncrementalSearchCV(model, params, random_state=0,
+    ...                              n_initial_parameters=1000,
+    ...                              patience=20, max_iter=100)
     """
 
     def __init__(
@@ -747,7 +747,7 @@ class IncrementalSearch(BaseIncrementalSearch):
         self.tol = tol
         self.scores_per_fit = scores_per_fit
         self.max_iter = max_iter
-        super(IncrementalSearch, self).__init__(
+        super(IncrementalSearchCV, self).__init__(
             estimator, param_distribution, test_size, random_state, scoring
         )
 

--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -190,7 +190,7 @@ hyperparameter optimization. These should be used when your full dataset doesn't
 fit in memory on a single machine.
 
 .. autosummary::
-   dask_ml.model_selection.IncrementalSearch
+   dask_ml.model_selection.IncrementalSearchCV
 
 Broadly speaking, incremental optimization starts with a batch of models (underlying
 estimators and hyperparameter combinationms) and repeatedly calls the underlying estimator's
@@ -201,7 +201,7 @@ estimators and hyperparameter combinationms) and repeatedly calls the underlying
    These estimators require the optional ``distributed`` library.
 
 Here's an example training on a "large" dataset (a Dask array) with the
-``IncrementalSearch``
+``IncrementalSearchCV``.
 
 .. ipython:: python
 
@@ -234,9 +234,9 @@ train-and-score them until we find the best one.
 
 .. ipython:: python
 
-    from dask_ml.model_selection import IncrementalSearch
+    from dask_ml.model_selection import IncrementalSearchCV
 
-    search = IncrementalSearch(model, params, random_state=0)
+    search = IncrementalSearchCV(model, params, random_state=0)
     search.fit(X, y, classes=[0, 1])
 
 Note that when you do post-fit tasks like ``search.score``, the underlying
@@ -256,7 +256,7 @@ to use post-estimation features like scoring or prediction, we recommend using
    model = ParallelPostFit(SGDClassifier(tol=1e-3,
                                          penalty="elasticnet",
                                          random_state=0))
-   search = IncrementalSearch(model, params, random_state=0)
+   search = IncrementalSearchCV(model, params, random_state=0)
    search.fit(X, y, classes=[0, 1])
    search.score(X, y)
 

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -337,7 +337,7 @@ def test_small(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5, 0.75, 1.0]}
-    search = IncrementalSearch(model, params, n_initial_parameters="grid")
+    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)
@@ -349,7 +349,7 @@ def test_smaller(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5]}
-    search = IncrementalSearch(model, params, n_initial_parameters="grid")
+    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -223,12 +223,15 @@ def test_search_basic(c, s, a, b):
         "param_alpha",
         "param_l1_ratio",
     }.issubset(set(search.cv_results_.keys()))
+
     assert all(isinstance(v, np.ndarray) for v in search.cv_results_.values())
-    assert (
-        search.cv_results_["test_score"][search.best_index_]
-        >= search.cv_results_["test_score"]
-    ).all()
-    assert search.cv_results_["rank_test_score"][search.best_index_] == 1
+    assert all(search.cv_results_["test_score"] >= 0)
+    assert all(search.cv_results_["rank_test_score"] >= 1)
+    assert all(search.cv_results_["partial_fit_calls"] >= 1)
+    assert len(np.unique(search.cv_results_["model_id"])) == len(
+        search.cv_results_["model_id"]
+    )
+
     X_, = yield c.compute([X])
 
     proba = search.predict_proba(X_)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -232,7 +232,7 @@ def test_search_basic(c, s, a, b):
         search.cv_results_["model_id"]
     )
     assert sorted(search.model_history_.keys()) == list(range(20))
-    assert search.model_history_[0][0].keys() == {
+    assert set(search.model_history_[0][0].keys()) == {
         "model_id",
         "params",
         "partial_fit_calls",

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -231,6 +231,15 @@ def test_search_basic(c, s, a, b):
     assert len(np.unique(search.cv_results_["model_id"])) == len(
         search.cv_results_["model_id"]
     )
+    assert sorted(search.model_history_.keys()) == list(range(20))
+    assert search.model_history_[0][0].keys() == {
+        "model_id",
+        "params",
+        "partial_fit_calls",
+        "partial_fit_time",
+        "score",
+        "score_time",
+    }
 
     X_, = yield c.compute([X])
 

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -39,7 +39,7 @@ def test_basic(c, s, a, b):
         del ret[random.choice(list(some_keys))]
         return ret
 
-    info, models, history = yield fit(
+    info, models, history, best = yield fit(
         model,
         param_list,
         X_train,
@@ -88,7 +88,7 @@ def test_basic(c, s, a, b):
 
     # smoke test for ndarray X_test and y_test
     X_test, y_test = yield c.compute([X_test, y_test])
-    info, models, history = yield fit(
+    info, models, history, best = yield fit(
         model,
         param_list,
         X_train,
@@ -160,7 +160,7 @@ def test_explicit(c, s, a, b):
         else:
             raise Exception()
 
-    info, models, history = yield fit(
+    info, models, history, best = yield fit(
         model,
         params,
         X,

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -256,12 +256,12 @@ def test_search_patience(c, s, a, b):
     )
     yield search.fit(X, y, classes=[0, 1])
 
-        assert d["partial_fit_calls"] <= 3
     assert search.history_
     for h in search.history_:
-    assert isinstance(search.best_estimator_, SGDClassifier)
-    assert search.best_score_ > 0
-    assert "visualize" not in search.__dict__
+        assert isinstance(search.best_estimator_, SGDClassifier)
+        assert search.best_score_ > 0
+        assert "visualize" not in search.__dict__
+        assert h["partial_fit_calls"] <= 3
 
     X_test, y_test = yield c.compute([X, y])
 


### PR DESCRIPTION
The PR makes 4 improvements to the incremental search API:

* renames `IncrementalSearch` to `IncrementalSearchCV`
* renames `history_results_` to `history_`
* adds `cv_results_` to mirror Scikit-learn's `RandomizedSearchCV`
* returns all model information from `_incremental.fit`
    * which is implemented as `model_history_` in `IncrementalSearchCV`
* allow `incremental._fit` to return multiple models
    * in `IncrementalSearchCV`, choose the best among those models.