### PR TITLE
Avoid infinite loop in IncrementalSearchCV with decay=0

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -871,7 +871,8 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
             next_time_step = 1
 
         while inverse(current_time_step) == inverse(next_time_step) and (
-            not self.patience
+            self.decay_rate
+            and not self.patience
             or next_time_step - current_time_step < self.scores_per_fit
         ):
             next_time_step += 1

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -337,7 +337,9 @@ def test_small(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5, 0.75, 1.0]}
-    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
+    search = IncrementalSearchCV(
+        model, params, n_initial_parameters="grid", decay_rate=0
+    )
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)


### PR DESCRIPTION
This avoids the loop, and hopefully does the correct thing.

IIUC, `decay=0` should be "just keep training all the models".