### PR TITLE
API: rename IncrementalSearchCV to AdaptiveSearchCV

### DIFF
--- a/dask_ml/model_selection/__init__.py
+++ b/dask_ml/model_selection/__init__.py
@@ -19,8 +19,8 @@ __all__ = [
 
 
 try:
-    from ._incremental import IncrementalSearchCV  # noqa: F401
+    from ._incremental import AdaptiveSearchCV  # noqa: F401
 
-    __all__.extend(["IncrementalSearchCV"])
+    __all__.extend(["AdaptiveSearchCV"])
 except ImportError:
     pass

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -612,23 +612,21 @@ class BaseIncrementalSearchCV(BaseEstimator, MetaEstimatorMixin):
         return self.scorer_(self.best_estimator_, X, y)
 
 
-class IncrementalSearchCV(BaseIncrementalSearchCV):
+class AdaptiveSearchCV(BaseIncrementalSearchCV):
     """
-    Incrementally search for hyper-parameters on models that support partial_fit
+    Adaptively search for hyper-parameters on models that support partial_fit
 
     .. note::
 
        This class depends on the optional ``distributed`` library.
 
-    This incremental hyper-parameter optimization class starts training the
+    This adaptive hyper-parameter optimization class starts training the
     model on many hyper-parameters on a small amount of data, and then only
     continues training those models that seem to be performing well.
 
     The number of actively trained hyper-parameter combinations decays
     with an inverse decay given by the initial number of parameters and the
-    decay rate:
-
-        n_models = n_initial_parameters * (n_batches ** -decay_rate)
+    decay rate.
 
     See the :ref:`User Guide <hyperparameter.incremental>` for more.
 
@@ -796,14 +794,14 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
     ...           'l1_ratio': np.linspace(0, 1, num=1000),
     ...           'average': [True, False]}
 
-    >>> search = IncrementalSearchCV(model, params, random_state=0)
+    >>> search = AdaptiveSearchCV(model, params, random_state=0)
     >>> search.fit(X, y, classes=[0, 1])
-    IncrementalSearchCV(...)
+    AdaptiveSearchCV(...)
 
     Alternatively you can provide keywords to start with more hyper-parameters,
     but stop those that don't seem to improve with more data.
 
-    >>> search = IncrementalSearchCV(model, params, random_state=0,
+    >>> search = AdaptiveSearchCV(model, params, random_state=0,
     ...                              n_initial_parameters=1000,
     ...                              patience=20, max_iter=100)
 
@@ -840,7 +838,7 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
         self.tol = tol
         self.scores_per_fit = scores_per_fit
         self.max_iter = max_iter
-        super(IncrementalSearchCV, self).__init__(
+        super(AdaptiveSearchCV, self).__init__(
             estimator, param_distribution, test_size, random_state, scoring
         )
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,7 @@ Note that this version of Dask-ML requires scikit-learn >= 0.20.0.
 Enhancements
 ------------
 
-- Added :class:`dask_ml.model_selection.IncrementalSearchCV`, a meta-estimator for hyperparamter optimization on larger-than-memory datasets (:pr:`356`). See :ref:`hyperparameter.incremental` for more.
+- Added :class:`dask_ml.model_selection.AdaptiveSearchCV`, a meta-estimator for hyperparamter optimization on larger-than-memory datasets (:pr:`356`). See :ref:`hyperparameter.incremental` for more.
 - Added :class:`dask_ml.preprocessing.PolynomialTransformer`, a drop-in replacement for the scikit-learn version (:issue:`347`).
 - Added auto-rechunking to Dask Arrays with more than one block along the features in :class:`dask_ml.model_selection.ParallelPostFit` (:issue:`376`)
 - Added support for Dask DataFrame inputs to :class:`dask_ml.cluster.KMeans` (:issue:`390`)

--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -190,7 +190,7 @@ hyperparameter optimization. These should be used when your full dataset doesn't
 fit in memory on a single machine.
 
 .. autosummary::
-   dask_ml.model_selection.IncrementalSearchCV
+   dask_ml.model_selection.AdaptiveSearchCV
 
 Broadly speaking, incremental optimization starts with a batch of models (underlying
 estimators and hyperparameter combinationms) and repeatedly calls the underlying estimator's
@@ -201,7 +201,7 @@ estimators and hyperparameter combinationms) and repeatedly calls the underlying
    These estimators require the optional ``distributed`` library.
 
 Here's an example training on a "large" dataset (a Dask array) with the
-``IncrementalSearchCV``.
+``AdaptiveSearchCV``.
 
 .. ipython:: python
 
@@ -234,9 +234,9 @@ train-and-score them until we find the best one.
 
 .. ipython:: python
 
-    from dask_ml.model_selection import IncrementalSearchCV
+    from dask_ml.model_selection import AdaptiveSearchCV
 
-    search = IncrementalSearchCV(model, params, random_state=0)
+    search = AdaptiveSearchCV(model, params, random_state=0)
     search.fit(X, y, classes=[0, 1])
 
 Note that when you do post-fit tasks like ``search.score``, the underlying
@@ -256,7 +256,7 @@ to use post-estimation features like scoring or prediction, we recommend using
    model = ParallelPostFit(SGDClassifier(tol=1e-3,
                                          penalty="elasticnet",
                                          random_state=0))
-   search = IncrementalSearchCV(model, params, random_state=0)
+   search = AdaptiveSearchCV(model, params, random_state=0)
    search.fit(X, y, classes=[0, 1])
    search.score(X, y)
 

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -10,7 +10,7 @@ from sklearn.model_selection import ParameterGrid, ParameterSampler
 from tornado import gen
 
 from dask_ml.datasets import make_classification
-from dask_ml.model_selection import IncrementalSearchCV
+from dask_ml.model_selection import AdaptiveSearchCV
 from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 
 
@@ -199,7 +199,7 @@ def test_search_basic(c, s, a, b):
 
     params = {"alpha": np.logspace(-2, 2, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-    search = IncrementalSearchCV(model, params, n_initial_parameters=20, max_iter=10)
+    search = AdaptiveSearchCV(model, params, n_initial_parameters=20, max_iter=10)
     yield search.fit(X, y, classes=[0, 1])
 
     assert search.history_
@@ -263,7 +263,7 @@ def test_search_patience(c, s, a, b):
 
     params = {"alpha": np.logspace(-2, 10, 100), "l1_ratio": np.linspace(0.01, 1, 200)}
 
-    search = IncrementalSearchCV(
+    search = AdaptiveSearchCV(
         model, params, n_initial_parameters=10, patience=5, tol=0, max_iter=10
     )
     yield search.fit(X, y, classes=[0, 1])
@@ -287,7 +287,7 @@ def test_search_max_iter(c, s, a, b):
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": np.logspace(-2, 10, 10), "l1_ratio": np.linspace(0.01, 1, 20)}
 
-    search = IncrementalSearchCV(model, params, n_initial_parameters=10, max_iter=1)
+    search = AdaptiveSearchCV(model, params, n_initial_parameters=10, max_iter=1)
     yield search.fit(X, y, classes=[0, 1])
     for d in search.history_:
         assert d["partial_fit_calls"] <= 1
@@ -301,7 +301,7 @@ def test_gridsearch(c, s, a, b):
 
     params = {"alpha": np.logspace(-2, 10, 3), "l1_ratio": np.linspace(0.01, 1, 2)}
 
-    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
+    search = AdaptiveSearchCV(model, params, n_initial_parameters="grid")
     yield search.fit(X, y, classes=[0, 1])
 
     assert {frozenset(d["params"].items()) for d in search.history_} == {
@@ -316,7 +316,7 @@ def test_numpy_array(c, s, a, b):
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": np.logspace(-2, 10, 10), "l1_ratio": np.linspace(0.01, 1, 20)}
 
-    search = IncrementalSearchCV(model, params, n_initial_parameters=10)
+    search = AdaptiveSearchCV(model, params, n_initial_parameters=10)
     yield search.fit(X, y, classes=[0, 1])
 
 
@@ -325,7 +325,7 @@ def test_transform(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = MiniBatchKMeans(random_state=0)
     params = {"n_clusters": [3, 4, 5], "n_init": [1, 2]}
-    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
+    search = AdaptiveSearchCV(model, params, n_initial_parameters="grid")
     yield search.fit(X, y)
     X_, = yield c.compute([X])
     result = search.transform(X_)
@@ -337,7 +337,7 @@ def test_small(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5, 0.75, 1.0]}
-    search = IncrementalSearchCV(
+    search = AdaptiveSearchCV(
         model, params, n_initial_parameters="grid", decay_rate=0
     )
     yield search.fit(X, y, classes=[0, 1])
@@ -351,7 +351,7 @@ def test_smaller(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5]}
-    search = IncrementalSearchCV(model, params, n_initial_parameters="grid")
+    search = AdaptiveSearchCV(model, params, n_initial_parameters="grid")
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -337,9 +337,7 @@ def test_small(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5, 0.75, 1.0]}
-    search = AdaptiveSearchCV(
-        model, params, n_initial_parameters="grid", decay_rate=0
-    )
+    search = AdaptiveSearchCV(model, params, n_initial_parameters="grid", decay_rate=0)
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)


### PR DESCRIPTION
**What does this PR implement?**
This PR renames `IncrementalSearchCV` to `AdaptiveSearchCV`.

Renaming to `AdaptiveSearchCV` would close #388: how can `AdaptiveSearchCV` not be adaptive by default? I think the name `AdaptiveSearchCV` aligns with the design goal: to use to previous calls to `partial_fit` to determine if training continue.

I think this will help provide clearer recommendations to the user because the name succinctly describes the features and design goals of this class.

I think some documentation changes should go around this too (I can add a WIP label, but documentation shouldn't be blocking).