### PR TITLE
Remove get= keyword

### DIFF
--- a/ci/environment-2.7.yml
+++ b/ci/environment-2.7.yml
@@ -19,7 +19,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - python=2.7
+  - python=2.7.14
   - sortedcontainers
   - scikit-learn>=0.20.0
   - scipy

--- a/ci/environment-3.6.yml
+++ b/ci/environment-3.6.yml
@@ -27,7 +27,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - python=3.6
+  - python=3.6.6
   - sortedcontainers
   - scikit-learn>=0.20.0
   - scipy

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -1187,10 +1187,7 @@ class DaskBaseSearchCV(BaseEstimator, MetaEstimatorMixin):
         self.n_splits_ = n_splits
 
         n_jobs = _normalize_n_jobs(self.n_jobs)
-        scheduler = dask.base.get_scheduler(
-            scheduler=(self.scheduler if isinstance(self.scheduler, str) else None),
-            get=self.scheduler if callable(self.scheduler) else None,
-        )
+        scheduler = dask.base.get_scheduler(scheduler=self.scheduler)
 
         if not scheduler:
             scheduler = dask.threaded.get

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -678,7 +678,11 @@ class DummyEncoder(BaseEstimator, TransformerMixin):
                 categories, ordered = self.dtypes_[col]
 
             # use .values to avoid warning from pandas
-            inds = X[list(X.columns[slice_])].values
+            cols_slice = list(X.columns[slice_])
+            if big:
+                inds = X[cols_slice].to_dask_array(lengths=chunks)
+            else:
+                inds = X[cols_slice].values
             codes = inds.argmax(1)
 
             if self.drop_first:

--- a/tests/linear_model/test_stochastic_gradient.py
+++ b/tests/linear_model/test_stochastic_gradient.py
@@ -61,7 +61,7 @@ class TestStochasticGradientRegressor(object):
 @pytest.mark.filterwarnings("ignore:'Partial:FutureWarning")
 def test_lazy(xy_classification):
     X, y = xy_classification
-    sgd = lm.PartialSGDClassifier(classes=[0, 1], max_iter=5)
+    sgd = lm.PartialSGDClassifier(classes=[0, 1], max_iter=5, tol=1e-3)
     r = sgd.fit(X, y, compute=False)
     assert isinstance(r, Delayed)
     result = r.compute()

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -769,7 +769,7 @@ def test_normalize_n_jobs():
         ("synchronous", 4),
         ("sync", 4),
         ("multiprocessing", 4),
-        (dask.local.get_sync, 4),
+        pytest.param(dask.get, 4, marks=[pytest.mark.filterwarnings("ignore")]),
     ],
 )
 def test_scheduler_param(scheduler, n_jobs):

--- a/tests/model_selection/dask_searchcv/test_model_selection.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection.py
@@ -769,7 +769,7 @@ def test_normalize_n_jobs():
         ("synchronous", 4),
         ("sync", 4),
         ("multiprocessing", 4),
-        pytest.param(dask.get, 4, marks=[pytest.mark.filterwarnings("ignore")]),
+        (dask.local.get_sync, 4),
     ],
 )
 def test_scheduler_param(scheduler, n_jobs):

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -155,7 +155,7 @@ def test_score(xy_classification):
 )
 def test_replace_scoring(estimator, fit_kwargs, scoring, xy_classification, mocker):
     X, y = xy_classification
-    inc = Incremental(estimator(max_iter=1000, random_state=0))
+    inc = Incremental(estimator(max_iter=1000, random_state=0, tol=1e-3))
     inc.fit(X, y, **fit_kwargs)
 
     patch = mocker.patch.object(dask_ml.wrappers, "get_scorer")

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -24,7 +24,7 @@ Z = da.from_array(z, chunks=(2, 2))
 
 def test_fit():
     with dask.config.set(scheduler="single-threaded"):
-        sgd = SGDClassifier(max_iter=5)
+        sgd = SGDClassifier(max_iter=5, tol=1e-3)
 
         sgd = fit(sgd, X, Y, classes=np.array([-1, 0, 1]))
 
@@ -41,7 +41,7 @@ def test_fit_rechunking():
 
     assert X.numblocks[1] > 1
 
-    clf = Incremental(SGDClassifier(max_iter=5))
+    clf = Incremental(SGDClassifier(max_iter=5, tol=1e-3))
     clf.fit(X, y, classes=list(range(n_classes)))
 
 
@@ -51,7 +51,9 @@ def test_fit_shuffle_blocks():
     y = da.from_array(np.ones(N), chunks=1)
     classes = [0, 1]
 
-    sgd = SGDClassifier(max_iter=5, random_state=0, fit_intercept=False, shuffle=False)
+    sgd = SGDClassifier(
+        max_iter=5, random_state=0, fit_intercept=False, shuffle=False, tol=1e-3
+    )
 
     sgd1 = fit(clone(sgd), X, y, random_state=0, classes=classes)
     sgd2 = fit(clone(sgd), X, y, random_state=42, classes=classes)
@@ -81,7 +83,7 @@ def test_dataframes():
     ddf = dd.from_pandas(df, npartitions=2)
 
     with dask.config.set(scheduler="single-threaded"):
-        sgd = SGDClassifier(max_iter=5)
+        sgd = SGDClassifier(max_iter=5, tol=1e-3)
 
         sgd = fit(sgd, ddf[["x"]], ddf.y, classes=[0, 1])
 


### PR DESCRIPTION
This PR removes an occurrences of the `get=` keyword in `dask-ml`

Related to error in #417