### PR TITLE
Fix typo in train_test_split docstring

### DIFF
--- a/dask_ml/model_selection/_split.py
+++ b/dask_ml/model_selection/_split.py
@@ -383,7 +383,7 @@ def train_test_split(*arrays, **options):
 
         The default behavior depends on the types in arrays. For Dask Arrays,
         the default is True (data are not shuffled between blocks). For Dask
-        DataFrames, the default and only allowed value is True (data are
+        DataFrames, the default and only allowed value is False (data are
         shuffled between blocks).
 
     Returns


### PR DESCRIPTION
Small fix for #428, which confused me as well