### PR TITLE
fix typo: model_selectoin -> model_selection

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Version 0.12.0
 API Breaking Changes
 --------------------
 
-- :class:`dask_ml.model_selectoin.IncrementalSearchCV` now returns Dask objects for post-fit methods like ``.predict``, etc (:issues:`423`).
+- :class:`dask_ml.model_selection.IncrementalSearchCV` now returns Dask objects for post-fit methods like ``.predict``, etc (:issues:`423`).
 
 
 Version 0.11.0


### PR DESCRIPTION
Typo fix in changelog