### PR TITLE
Fix incremental bug with Dask sharedict

### DIFF
--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -205,7 +205,7 @@ def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None, **kwa
     except ImportError:
         from dask import sharedict
 
-        new_dsk = sharedict.merge(graphs.values)
+        new_dsk = sharedict.merge(*graphs.values())
 
     value = Delayed((name, nblocks - 1), new_dsk)
 


### PR DESCRIPTION
Currently we're passing a dictionary `values` method to `sharedict.merge` instead of the actual values themselves. Fixes #454.