### PR TITLE
Add graphviz to dev environment

### DIFF
--- a/ci/environment-2.7.yml
+++ b/ci/environment-2.7.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - coverage
   - flake8
+  - graphviz
   - heapdict
   - ipython
   - multipledispatch
@@ -40,3 +41,4 @@ dependencies:
     - git+https://github.com/dask/distributed.git
     - git+https://github.com/dask/dask-tensorflow.git
     - git+https://github.com/dask/dask-xgboost.git
+    - graphviz

--- a/ci/environment-3.6.yml
+++ b/ci/environment-3.6.yml
@@ -11,6 +11,7 @@ dependencies:
   - coverage
   - codecov
   - flake8
+  - graphviz
   - heapdict
   - ipykernel
   - ipython
@@ -49,3 +50,4 @@ dependencies:
     - git+https://github.com/dask/dask-tensorflow.git
     - git+https://github.com/dask/dask-xgboost.git
     - dask_sphinx_theme >=1.1.0
+    - graphviz


### PR DESCRIPTION
This PR adds both the system and Python `graphviz` package to the dev environment for dask-ml. `graphviz` is needed for building the documentation. Closes #457.