### PR TITLE
Contributing: `distributed` not installed with `[dev]` extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ test_requires = [
     "pytest-cover",
     "pytest-mock",
 ]
-dev_requires = doc_requires + test_requires
+dev_requires = doc_requires + test_requires + ["distributed"]
 tensorflow_requires = ["dask-tensorflow", "tensorflow"]
 xgboost_requires = ["dask-xgboost", "xgboost"]
 complete_requires = tensorflow_requires + xgboost_requires


### PR DESCRIPTION
Hello,

I just followed the [contributing guide](https://ml.dask.org/contributing.html#building-dask-ml), which recommends a sensible `python -m pip install -e ".[dev]"`, but unfortunately my first step was to ensure that existing tests pass before making any changes, and `pytest tests/` raised an `ImportError` that I assume is related to `dask.distributed`.

```plaintext
ImportError while loading conftest '/home/n8henrie/git/dask-ml/tests/conftest.py'.
tests/conftest.py:7: in <module>
    from distributed.utils_test import cluster
E   ModuleNotFoundError: No module named 'distributed'
```

I was able to work around by also installing `.[complete]` (though in retrospect it looks like I could have just installed `distributed` alone, I thought there could be a handful of missing dependencies that I'd have to discover one by one, so I went with `complete` to make sure it was taken care of in a single install).

It seems like the recommended setup in the contributing guide should lead to a point where one can at least run the tests -- I recommend either a change to the contributing guide to additionally recommend a manual installation of this dependency (in a quick glance I didn't see how to add a PR to the page), or possibly by adding `distributed` to the dev dependencies, or by including the `complete` dependencies to the `dev` dependencies.

Happy to make this (super minor) change into a PR if one of these is thought to be a best course of action.