### PR TITLE
Change `da.atop` that has been replaced by `da.blockwise` in 

### DIFF
--- a/dask_ml/cluster/k_means.py
+++ b/dask_ml/cluster/k_means.py
@@ -531,7 +531,7 @@ def _kmeans_single_lloyd(
             labels = labels.astype(np.int32)
             # distances is always float64, but we need it to match X.dtype
             # for centers_dense, but remain float64 for inertia
-            r = da.atop(
+            r = da.blockwise(
                 _centers_dense,
                 "ij",
                 X,

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -652,7 +652,7 @@ class DummyEncoder(BaseEstimator, TransformerMixin):
             # known divisions. Suboptimal, but I think unavoidable.
             unknown = np.isnan(X.chunks[0]).any()
             if unknown:
-                lengths = da.atop(len, "i", X[:, 0], "i", dtype="i8").compute()
+                lengths = da.blockwise(len, "i", X[:, 0], "i", dtype="i8").compute()
                 X = X.copy()
                 chunks = (tuple(lengths), X.chunks[1])
                 X._chunks = chunks
@@ -871,7 +871,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
             # known divisions. Suboptimal, but I think unavoidable.
             unknown = np.isnan(X.chunks[0]).any()
             if unknown:
-                lengths = da.atop(len, "i", X[:, 0], "i", dtype="i8").compute()
+                lengths = da.blockwise(len, "i", X[:, 0], "i", dtype="i8").compute()
                 X = X.copy()
                 chunks = (tuple(lengths), X.chunks[1])
                 X._chunks = chunks


### PR DESCRIPTION
**Context**:
 - in `dask`, `da.atop` has been replace by `da.blockwise` defined in the same scope — see [dask source](https://github.com/dask/dask/blob/master/dask/array/blockwise.py#L203) ;
 - in `cluster.KMeans`, warnings are thrown because `da.atop` is used ;

**Changes proposed:**
 - replace `da.atop` by `da.blockwise` to remove those warnings ;