### PR TITLE
Fix imports for isort 4.3.10

### DIFF
--- a/dask_ml/cluster/spectral.py
+++ b/dask_ml/cluster/spectral.py
@@ -12,10 +12,10 @@ from scipy.linalg import pinv, svd
 from sklearn.base import BaseEstimator, ClusterMixin
 from sklearn.utils import check_random_state
 
-from .k_means import KMeans
 from .._utils import draw_seed
 from ..metrics.pairwise import PAIRWISE_KERNEL_FUNCTIONS, pairwise_kernels
 from ..utils import _format_bytes, _log_array, check_array
+from .k_means import KMeans
 
 logger = logging.getLogger(__name__)
 

--- a/dask_ml/linear_model/glm.py
+++ b/dask_ml/linear_model/glm.py
@@ -14,8 +14,6 @@ from dask_glm.utils import (
 )
 from sklearn.base import BaseEstimator
 
-# Register multiple dispatch
-from . import utils  # noqa
 from ..utils import check_array
 
 _base_doc = textwrap.dedent(

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -20,9 +20,9 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.validation import check_is_fitted
 from tornado import gen
 
-from ._split import train_test_split
 from ..utils import check_array
 from ..wrappers import ParallelPostFit
+from ._split import train_test_split
 
 Results = namedtuple("Results", ["info", "models", "history", "best"])
 

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -33,6 +33,7 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _num_samples, check_is_fitted
 
+from .._compat import SK_VERSION
 from ._normalize import normalize_estimator
 from .methods import (
     MISSING,
@@ -53,7 +54,6 @@ from .methods import (
     score,
 )
 from .utils import DeprecationDict, is_dask_collection, to_indexable, to_keys, unzip
-from .._compat import SK_VERSION
 
 try:
     from cytoolz import get, pluck

--- a/dask_ml/model_selection/methods.py
+++ b/dask_ml/model_selection/methods.py
@@ -16,8 +16,8 @@ from sklearn.utils import safe_indexing
 from sklearn.utils.validation import check_consistent_length
 from toolz import pluck
 
-from .utils import _index_param_value, _num_samples, copy_estimator
 from .._compat import Mapping
+from .utils import _index_param_value, _num_samples, copy_estimator
 
 # Copied from scikit-learn/sklearn/utils/fixes.py, can be removed once we drop
 # support for scikit-learn < 0.18.1 or numpy < 1.12.0.

--- a/dask_ml/preprocessing/_encoders.py
+++ b/dask_ml/preprocessing/_encoders.py
@@ -5,9 +5,9 @@ import packaging.version
 import pandas as pd
 import sklearn.preprocessing
 
-from .label import _encode, _encode_dask_array
 from .._compat import SK_VERSION
 from ..utils import check_array
+from .label import _encode, _encode_dask_array
 
 
 class OneHotEncoder(sklearn.preprocessing.OneHotEncoder):


### PR DESCRIPTION
The new release of `isort` (version 4.3.10) changed how relative import sorting is handled. This PR makes updates to have v4.3.10 of `isort` pass. 