### PR TITLE
Issue 478 fix -- Documentation link error

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -386,7 +386,7 @@ class Incremental(ParallelPostFit):
     used during the call to ``fit``. All attributes learned during training
     are available on ``Incremental`` directly.
 
-    .. _list of incremental learners: https://scikit-learn.org/0.15/modules/scaling_strategies.html  # noqa
+    .. _list of incremental learners: https://scikit-learn.org/0.15/modules/scaling_strategies.html#incremental-learning  # noqa
 
     Parameters
     ----------

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -386,7 +386,7 @@ class Incremental(ParallelPostFit):
     used during the call to ``fit``. All attributes learned during training
     are available on ``Incremental`` directly.
 
-    .. _list of incremental learners: https://scikit-learn.org/0.15/modules/scaling_strategies.html#incremental-learning  # noqa
+    .. _list of incremental learners: https://scikit-learn.org/stable/modules/computing.html#incremental-learning  # noqa
 
     Parameters
     ----------

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -386,7 +386,7 @@ class Incremental(ParallelPostFit):
     used during the call to ``fit``. All attributes learned during training
     are available on ``Incremental`` directly.
 
-    .. _list of incremental learners: http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning  # noqa
+    .. _list of incremental learners: https://scikit-learn.org/0.15/modules/scaling_strategies.html  # noqa
 
     Parameters
     ----------


### PR DESCRIPTION
In the https://ml.dask.org/modules/generated/dask_ml.wrappers.Incremental.html#dask_ml.wrappers.Incremental there is a link which redirects to scikit learn scaling strategies page when you click the list of incremental learners and it is not working anymore and  I updated the new link.