### PR TITLE
BUG: make IncrementalSearchCV use random_state when sampling parameters

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -837,7 +837,11 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
         if self.n_initial_parameters == "grid":
             return ParameterGrid(self.parameters)
         else:
-            return ParameterSampler(self.parameters, self.n_initial_parameters)
+            return ParameterSampler(
+                self.parameters,
+                self.n_initial_parameters,
+                random_state=self.random_state,
+            )
 
     def _additional_calls(self, info):
         # First, have an adaptive algorithm

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -427,3 +427,24 @@ def test_smaller(c, s, a, b):
     yield search.fit(X, y, classes=[0, 1])
     X_, = yield c.compute([X])
     search.predict(X_)
+
+
+@gen_cluster(client=True)
+def test_same_params_with_random_state(c, s, a, b):
+    X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
+    model = SGDClassifier(tol=1e-3, penalty="elasticnet")
+    params = {"alpha": np.logspace(-3, 0, num=1000)}
+
+    search1 = IncrementalSearchCV(
+        model, params, n_initial_parameters=10, random_state=0
+    )
+    yield search1.fit(X, y, classes=[0, 1])
+    params1 = search1.cv_results_["param_alpha"]
+
+    search2 = IncrementalSearchCV(
+        model, params, n_initial_parameters=10, random_state=0
+    )
+    yield search2.fit(X, y, classes=[0, 1])
+    params2 = search2.cv_results_["param_alpha"]
+
+    assert np.allclose(params1, params2)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -2,6 +2,7 @@ import random
 
 import dask.array as da
 import numpy as np
+import scipy
 import toolz
 from dask.distributed import Future
 from distributed.utils_test import cluster, gen_cluster, loop  # noqa: F401
@@ -433,7 +434,7 @@ def test_smaller(c, s, a, b):
 def test_same_params_with_random_state(c, s, a, b):
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
-    params = {"alpha": np.logspace(-3, 0, num=1000)}
+    params = {"alpha": scipy.stats.uniform(1e-4, 1)}
 
     search1 = IncrementalSearchCV(
         model, params, n_initial_parameters=10, random_state=0


### PR DESCRIPTION
**What does this PR implement?**
This preserves the `random_state` in `IncrementalSearchCV`'s parameter sampler. Before, the `ParameterSampler` object didn't have `random_state` specified so multiple calls to `IncrementalSearchCV` with the same random state had no effect on the parameters sampled.

**Reference issues**
* Motivating comment: https://github.com/dask/dask-ml/pull/221/files#r272723216
