### PR TITLE
Correct doc wrap to sklearn mean_absolute_error

### DIFF
--- a/dask_ml/metrics/regression.py
+++ b/dask_ml/metrics/regression.py
@@ -44,7 +44,7 @@ def mean_squared_error(
     return result
 
 
-@doc_wraps(sklearn.metrics.mean_squared_error)
+@doc_wraps(sklearn.metrics.mean_absolute_error)
 def mean_absolute_error(
     y_true, y_pred, sample_weight=None, multioutput="uniform_average", compute=True
 ):


### PR DESCRIPTION
Currently mean_absolute_error is wrapping to mean_squared_error