### PR TITLE
BUG: fixes layering of stop-on-plateau with adaptive algs 

### DIFF
--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -193,7 +193,7 @@ fit in memory on a single machine.
    dask_ml.model_selection.IncrementalSearchCV
 
 Broadly speaking, incremental optimization starts with a batch of models (underlying
-estimators and hyperparameter combinationms) and repeatedly calls the underlying estimator's
+estimators and hyperparameter combinations) and repeatedly calls the underlying estimator's
 ``partial_fit`` method with batches of data.
 
 .. note::


### PR DESCRIPTION
**What does this PR implement?**
It squares a bug with laying stop-on-plateau on top of adaptive algs and implements a test to make sure it works.

It also raises a warning if `patience` is too small for `IncrementalSearchCV`. It `patience=1` a plateau will always be detected.

**Reference issues/PRs**
This fixes #523.