### PR TITLE
DOC Joblib is no longer vendored in scikit-learn

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,11 +48,11 @@ optimization, and more.
 .. code-block:: python
 
    from dask.distributed import Client
-   from sklearn.externals.joblib import parallel_backend
+   import joblib
 
    client = Client()  # Connect to a Dask Cluster
 
-   with parallel_backend('dask'):
+   with joblib.parallel_backend('dask'):
        # Your normal scikit-learn code here
 
 See :doc:`Dask-ML Joblib documentation <joblib>` for more information.

--- a/docs/source/joblib.rst
+++ b/docs/source/joblib.rst
@@ -28,7 +28,7 @@ code with ``joblib.parallel_backend('dask')``.
 .. code-block:: python
 
    from dask.distributed import Client
-   from sklearn.externals import joblib
+   import joblib
 
    client = Client(processes=False)             # create local cluster
    # client = Client("scheduler-address:8786")  # or connect to remote cluster
@@ -44,7 +44,7 @@ search as follows:
    import numpy as np
    from dask.distributed import Client
 
-   from sklearn.externals import joblib
+   import joblib
    from sklearn.datasets import load_digits
    from sklearn.model_selection import RandomizedSearchCV
    from sklearn.svm import SVC


### PR DESCRIPTION
scikit-learn, as of 0.21.0, no longer vendors joblib which [became a dependency](https://github.com/scikit-learn/scikit-learn/blob/a243d96336cb4f50ca3635b3062a273f3dc5183a/setup.py#L231).