### PR TITLE
WIP: allow not running passive bracket in HyperbandSearchCV

### DIFF
--- a/tests/model_selection/test_hyperband.py
+++ b/tests/model_selection/test_hyperband.py
@@ -419,3 +419,14 @@ def test_history(c, s, a, b):
     for model_hist in alg.model_history_.values():
         calls = [h["partial_fit_calls"] for h in model_hist]
         assert (np.diff(calls) >= 1).all() or len(calls) == 1
+
+
+@gen_cluster(client=True, timeout=5000)
+def test_patience_brackets(c, s, a, b):
+    X, y = make_classification(n_samples=10, n_features=4, chunks=10)
+    model = ConstantFunction()
+    params = {"value": scipy.stats.uniform(0, 1)}
+    search = HyperbandSearchCV(model, params, max_iter=9, patience=True)
+    yield search.fit(X, y)
+
+    assert all("bracket=0" not in h for h in search.history_)


### PR DESCRIPTION
*This PR is not ready to be merged. I still need to verify the implementation.*

**What does this PR implement?**
This PR allows skipping the bracket that trains all models to completion if `bool(patience)`.  This bracket is likely of marginal use because the hyperparameters will (almost certainly) influence the score. Why not eliminate this bracket instead of designing `patience=True` to accommodate this bracket?

**Reference issues/PRs**
* the prioritization scheme (#527). This means higher scoring models are run first.
* (future) keyboard interrupts (https://github.com/dask/dask-ml/pull/528#issuecomment-506484960).

These two features mean that the user can exit out of hyper-parameter selection when the score is high enough.

**TODO**

- [x] implement
- [ ] verify that `bracket=0` returns low scores
- [ ] run simulations to see how much this time-to-solution
- [ ] document

[my SciPy19 talk]:https://www.youtube.com/watch?v=x67K9FiPFBQ

