### PR TITLE
DOC: Fixed yaml/yml typo in contributing.rst

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -29,7 +29,7 @@ in the ``ci`` directory.
 
 .. code-block:: none
 
-   conda env create -f ci/environment-3.7.yml --name=dask-ml-dev
+   conda env create -f ci/environment-3.7.yaml --name=dask-ml-dev
 
 to create a conda environment and install all the dependencies.
 


### PR DESCRIPTION
Minor typo fix in contributing docs. conda env filename extension is .yaml, but docs used .yml