### PR TITLE
[BUG] Preserve index in PolynomialFeatures

### DIFF
--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -1013,12 +1013,12 @@ class PolynomialFeatures(sklearn.preprocessing.PolynomialFeatures):
             XP = X.pipe(self._transformer.transform)
             if self.preserve_dataframe:
                 columns = self._transformer.get_feature_names(X.columns)
-                XP = pd.DataFrame(data=XP, columns=columns)
+                XP = pd.DataFrame(data=XP, columns=columns, index=X.index)
         elif isinstance(X, dd.DataFrame):
             XP = X.map_partitions(self._transformer.transform)
             if self.preserve_dataframe:
                 columns = self._transformer.get_feature_names(X.columns)
-                XP = dd.from_dask_array(XP, columns)
+                XP = dd.from_dask_array(XP, columns, X.index)
         else:
             # typically X is instance of np.ndarray
             XP = self._transformer.transform(X)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -568,7 +568,7 @@ class TestPolynomialFeatures:
             res_pandas = a.fit_transform(frame.compute())
             assert dask.is_dask_collection(res_df)
             assert dask.is_dask_collection(res_arr)
-            assert_eq_df(res_df.compute(), res_pandas)
+            assert_eq_df(res_df, res_pandas)
         assert_eq_ar(res_df.values, res_c)
         assert_eq_ar(res_df.values, res_arr)
 
@@ -588,6 +588,4 @@ class TestPolynomialFeatures:
         res_df = dpp.PolynomialFeatures(
             preserve_dataframe=True, degree=1
         ).fit_transform(frame)
-        if daskify:
-            res_df = res_df.compute()
         assert_eq_df(res_df.iloc[:, 1:], frame, check_dtype=False)


### PR DESCRIPTION
Closes #562.

I'm now adding the index back on. 

I also added a test. If there's a more elegant way to reshuffle the index than `sample`, please let me know. 

I also made one of the existing tests stricter by removing a now unnecessary `reset_index=True` (https://github.com/dask/dask-ml/blob/master/tests/preprocessing/test_data.py#L568). 