### PR TITLE
Preserve non-arrays in partial

### DIFF
--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -15,6 +15,7 @@ PANDAS_VERSION = packaging.version.parse(pandas.__version__)
 SK_022 = SK_VERSION >= packaging.version.parse("0.22.dev0")
 DASK_110 = DASK_VERSION >= packaging.version.parse("1.1.0")
 DASK_200 = DASK_VERSION >= packaging.version.parse("2.0.0")
+DASK_240 = DASK_VERSION >= packaging.version.parse("2.4.0")
 
 
 @contextlib.contextmanager

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -91,7 +91,16 @@ def _partial_fit(model, x, y, kwargs=None):
     return model
 
 
-def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None, **kwargs):
+def fit(
+    model,
+    x,
+    y,
+    compute=True,
+    shuffle_blocks=True,
+    random_state=None,
+    assume_equal_chunks=False,
+    **kwargs
+):
     """ Fit scikit learn model against dask arrays
 
     Model must support the ``partial_fit`` interface for online or batch
@@ -146,44 +155,47 @@ def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None, **kwa
     >>> da.learn.predict(sgd, z)  # doctest: +SKIP
     dask.array<x_11, shape=(400,), chunks=((100, 100, 100, 100),), dtype=int64>
     """
-    if not hasattr(x, "chunks") and hasattr(x, "to_dask_array"):
-        x = x.to_dask_array()
-    assert x.ndim == 2
+
+    nblocks, x_name = _blocks_and_name(x)
     if y is not None:
-        if not hasattr(y, "chunks") and hasattr(y, "to_dask_array"):
-            y = y.to_dask_array()
+        y_nblocks, y_name = _blocks_and_name(y)
+        assert y_nblocks == nblocks
+    else:
+        y_name = ""
 
-        assert y.ndim == 1
-        assert x.chunks[0] == y.chunks[0]
+    if not hasattr(model, "partial_fit"):
+        msg = "The class '{}' does not implement 'partial_fit'."
+        raise ValueError(msg.format(type(model)))
 
-    assert hasattr(model, "partial_fit")
-    if len(x.chunks[1]) > 1:
-        x = x.rechunk(chunks=(x.chunks[0], sum(x.chunks[1])))
-
-    nblocks = len(x.chunks[0])
     order = list(range(nblocks))
     if shuffle_blocks:
         rng = sklearn.utils.check_random_state(random_state)
         rng.shuffle(order)
 
     name = "fit-" + dask.base.tokenize(model, x, y, kwargs, order)
+
+    if hasattr(x, "chunks") and x.ndim > 1:
+        x_extra = (0,)
+    else:
+        x_extra = ()
+
     dsk = {(name, -1): model}
     dsk.update(
         {
             (name, i): (
                 _partial_fit,
                 (name, i - 1),
-                (x.name, order[i], 0),
-                (getattr(y, "name", ""), order[i]),
+                (x_name, order[i]) + x_extra,
+                (y_name, order[i]),
                 kwargs,
             )
             for i in range(nblocks)
         }
     )
 
-    graphs = {x.name: x.__dask_graph__(), name: dsk}
+    graphs = {x_name: x.__dask_graph__(), name: dsk}
     if hasattr(y, "__dask_graph__"):
-        graphs[y.name] = y.__dask_graph__()
+        graphs[y_name] = y.__dask_graph__()
 
     try:
         from dask.highlevelgraph import HighLevelGraph
@@ -200,6 +212,24 @@ def fit(model, x, y, compute=True, shuffle_blocks=True, random_state=None, **kwa
         return value.compute()
     else:
         return value
+
+
+def _blocks_and_name(obj):
+    if hasattr(obj, "chunks"):
+        nblocks = len(obj.chunks[0])
+        name = obj.name
+
+    elif hasattr(obj, "npartitions"):
+        # dataframe, bag
+        nblocks = obj.npartitions
+        if hasattr(obj, "_name"):
+            # dataframe
+            name = obj._name
+        else:
+            # bag
+            name = obj.name
+
+    return nblocks, name
 
 
 def _predict(model, x):

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -451,10 +451,16 @@ class Incremental(ParallelPostFit):
     """
 
     def __init__(
-        self, estimator=None, scoring=None, shuffle_blocks=True, random_state=None
+        self,
+        estimator=None,
+        scoring=None,
+        shuffle_blocks=True,
+        random_state=None,
+        assume_equal_chunks=True,
     ):
         self.shuffle_blocks = shuffle_blocks
         self.random_state = random_state
+        self.assume_equal_chunks = assume_equal_chunks
         super(Incremental, self).__init__(estimator=estimator, scoring=scoring)
 
     @property
@@ -473,6 +479,7 @@ class Incremental(ParallelPostFit):
                 y,
                 random_state=self.random_state,
                 shuffle_blocks=self.shuffle_blocks,
+                assume_equal_chunks=self.assume_equal_chunks,
                 **fit_kwargs
             )
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -13,7 +13,7 @@ from sklearn.pipeline import make_pipeline
 
 import dask_ml.feature_extraction.text
 import dask_ml.metrics
-from dask_ml._compat import SK_022
+from dask_ml._compat import DASK_240, SK_022
 from dask_ml.metrics.scorer import check_scoring
 from dask_ml.wrappers import Incremental
 
@@ -211,7 +211,8 @@ def test_incremental_text_pipeline(container):
 
     pipe.fit(X, y, incremental__classes=[0, 1])
     X2 = pipe.steps[0][1].transform(X)
-
-    X2.compute_chunk_sizes()
-    assert X2.shape == (300, vect.n_features)
     assert hasattr(clf, "coef_")
+
+    if DASK_240:
+        X2.compute_chunk_sizes()
+        assert X2.shape == (300, vect.n_features)

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -2,13 +2,16 @@ import dask
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
+import pandas as pd
 import pytest
 import sklearn.datasets
 import sklearn.model_selection
 from dask.array.utils import assert_eq
 from sklearn.base import clone
 from sklearn.linear_model import SGDClassifier, SGDRegressor
+from sklearn.pipeline import make_pipeline
 
+import dask_ml.feature_extraction.text
 import dask_ml.metrics
 from dask_ml._compat import SK_022
 from dask_ml.metrics.scorer import check_scoring
@@ -187,3 +190,28 @@ def test_replace_scoring(estimator, fit_kwargs, scoring, xy_classification, mock
 
     assert patch.call_count == 1
     patch.assert_called_with(scoring, compute=True)
+
+
+@pytest.mark.parametrize("container", ["bag", "series"])
+def test_incremental_text_pipeline(container):
+    X = pd.Series(["a list", "of words", "for classification"] * 100)
+    X = dd.from_pandas(X, npartitions=3)
+
+    if container == "bag":
+        X = X.to_bag()
+
+    y = da.from_array(np.array([0, 0, 1] * 100), chunks=(100,) * 3)
+
+    assert tuple(X.map_partitions(len).compute()) == y.chunks[0]
+
+    sgd = SGDClassifier(max_iter=5, tol=1e-3)
+    clf = Incremental(sgd, scoring="accuracy", assume_equal_chunks=True)
+    vect = dask_ml.feature_extraction.text.HashingVectorizer()
+    pipe = make_pipeline(vect, clf)
+
+    pipe.fit(X, y, incremental__classes=[0, 1])
+    X2 = pipe.steps[0][1].transform(X)
+
+    X2.compute_chunk_sizes()
+    assert X2.shape == (300, vect.n_features)
+    assert hasattr(clf, "coef_")


### PR DESCRIPTION
This is useful for pipelines that start with non-ndarrays, e.g. text classification.