### PR TITLE
ENH: PCA works with NumPy/Pandas data

### DIFF
--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -192,7 +192,8 @@ class PCA(sklearn.decomposition.PCA):
             msg = (
                 "Got an unsupported type ({}). To resolve this issue,\n\n"
                 "  * Use sklearn.decomposition.PCA  # recommended\n\n"
-                "Wrapping the input with a Dask Array/DataFrame is "
+                "Wrapping the input with a Dask Array/DataFrame will resolve "
+                "this issue but is "
                 "*not recommended* (Dask-ML's PCA implementation will likely "
                 "be slower because the data fit in memory)"
             )
@@ -410,7 +411,8 @@ class PCA(sklearn.decomposition.PCA):
             msg = (
                 "Got an unsupported type ({}). To resolve this issue,\n\n"
                 "  * Use sklearn.decomposition.PCA  # recommended\n\n"
-                "Wrapping the input with a Dask Array/DataFrame is "
+                "Wrapping the input with a Dask Array/DataFrame will resolve "
+                "this issue but is "
                 "*not recommended* (Dask-ML's PCA implementation will likely "
                 "be slower because the data fit in memory)"
             )

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -189,19 +189,14 @@ class PCA(sklearn.decomposition.PCA):
 
     def fit(self, X, y=None):
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            est = sklearn.decomposition.PCA(
-                n_components=self.n_components,
-                copy=self.copy,
-                whiten=self.whiten,
-                svd_solver=self.svd_solver,
-                tol=self.tol,
-                iterated_power=self.iterated_power,
-                random_state=self.random_state,
+            msg = (
+                "Got an unsupported type ({}). To resolve this issue,\n\n"
+                "  * Use sklearn.decomposition.PCA  # recommended!\n\n"
+                "Wrapping the input with a Dask Array/DataFrame is "
+                "*not recommended* (Dask-ML's PCA implementation will likely "
+                "be slower because the data fit in memory)"
             )
-            est.fit(X)
-            attrs = [k for k in dir(est) if k[0] != "_" and k[-1] == "_"]
-            _copy_attrs(est, self, attrs)
-            return self
+            raise ValueError(msg.format(X.shape))
         self._fit(X)
         return self
 

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -12,7 +12,7 @@ from sklearn.utils.validation import check_random_state
 
 from .._compat import check_is_fitted
 from .._utils import draw_seed
-from ..utils import _copy_attrs, svd_flip
+from ..utils import svd_flip
 
 
 class PCA(sklearn.decomposition.PCA):

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -1,5 +1,6 @@
 import numbers
 
+import dask
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
@@ -197,8 +198,8 @@ class PCA(sklearn.decomposition.PCA):
         self.random_state = random_state
 
     def fit(self, X, y=None):
-        if isinstance(X, (np.ndarray, pd.DataFrame)):
-            raise ValueError(_TYPE_MSG.format(type(X)))
+        if not dask.is_dask_collection(X):
+            raise TypeError(_TYPE_MSG.format(type(X)))
         self._fit(X)
         return self
 
@@ -262,9 +263,6 @@ class PCA(sklearn.decomposition.PCA):
                 )
             )
             raise ValueError(msg)
-
-        if sp.issparse(X):
-            raise TypeError("Cannot fit PCA on sparse 'X'")
 
         self.mean_ = X.mean(0)
         X -= self.mean_
@@ -408,8 +406,8 @@ class PCA(sklearn.decomposition.PCA):
 
         """
         # X = check_array(X)
-        if isinstance(X, (np.ndarray, pd.DataFrame)):
-            raise ValueError(_TYPE_MSG.format(type(X)))
+        if not dask.is_dask_collection(X):
+            raise TypeError(_TYPE_MSG.format(type(X)))
         U, S, V = self._fit(X)
         U = U[:, : self.n_components_]
 

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -14,6 +14,15 @@ from .._compat import check_is_fitted
 from .._utils import draw_seed
 from ..utils import svd_flip
 
+TYPE_MSG = (
+    "Got an unsupported type ({}). Dask-ML's PCA only support Dask Arrays or "
+    "DataFrames.\n\nTo resolve this issue,\n\n"
+    "  * Use Scikit-learn's PCA through `sklearn.decomposition.PCA`  # recommended\n\n"
+    "Wrapping the input with a Dask Array/DataFrame will resolve "
+    "this issue but is *not recommended* because Dask-ML's PCA "
+    "implementation will likely be slower because the data fits in memory"
+)
+
 
 class PCA(sklearn.decomposition.PCA):
     """Principal component analysis (PCA)
@@ -189,15 +198,7 @@ class PCA(sklearn.decomposition.PCA):
 
     def fit(self, X, y=None):
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            msg = (
-                "Got an unsupported type ({}). To resolve this issue,\n\n"
-                "  * Use sklearn.decomposition.PCA  # recommended\n\n"
-                "Wrapping the input with a Dask Array/DataFrame will resolve "
-                "this issue but is "
-                "*not recommended* (Dask-ML's PCA implementation will likely "
-                "be slower because the data fit in memory)"
-            )
-            raise ValueError(msg.format(X.shape))
+            raise ValueError(TYPE_MSG.format(type(X)))
         self._fit(X)
         return self
 
@@ -408,15 +409,7 @@ class PCA(sklearn.decomposition.PCA):
         """
         # X = check_array(X)
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            msg = (
-                "Got an unsupported type ({}). To resolve this issue,\n\n"
-                "  * Use sklearn.decomposition.PCA  # recommended\n\n"
-                "Wrapping the input with a Dask Array/DataFrame will resolve "
-                "this issue but is "
-                "*not recommended* (Dask-ML's PCA implementation will likely "
-                "be slower because the data fit in memory)"
-            )
-            raise ValueError(msg.format(X.shape))
+            raise ValueError(TYPE_MSG.format(type(X)))
         U, S, V = self._fit(X)
         U = U[:, : self.n_components_]
 

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -191,7 +191,7 @@ class PCA(sklearn.decomposition.PCA):
         if isinstance(X, (np.ndarray, pd.DataFrame)):
             msg = (
                 "Got an unsupported type ({}). To resolve this issue,\n\n"
-                "  * Use sklearn.decomposition.PCA  # recommended!\n\n"
+                "  * Use sklearn.decomposition.PCA  # recommended\n\n"
                 "Wrapping the input with a Dask Array/DataFrame is "
                 "*not recommended* (Dask-ML's PCA implementation will likely "
                 "be slower because the data fit in memory)"
@@ -407,16 +407,14 @@ class PCA(sklearn.decomposition.PCA):
         """
         # X = check_array(X)
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            est = sklearn.decomposition.PCA(
-                n_components=self.n_components,
-                copy=self.copy,
-                whiten=self.whiten,
-                svd_solver=self.svd_solver,
-                tol=self.tol,
-                iterated_power=self.iterated_power,
-                random_state=self.random_state,
+            msg = (
+                "Got an unsupported type ({}). To resolve this issue,\n\n"
+                "  * Use sklearn.decomposition.PCA  # recommended\n\n"
+                "Wrapping the input with a Dask Array/DataFrame is "
+                "*not recommended* (Dask-ML's PCA implementation will likely "
+                "be slower because the data fit in memory)"
             )
-            return est.fit_transform(X)
+            raise ValueError(msg.format(X.shape))
         U, S, V = self._fit(X)
         U = U[:, : self.n_components_]
 

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -14,7 +14,7 @@ from .._compat import check_is_fitted
 from .._utils import draw_seed
 from ..utils import svd_flip
 
-TYPE_MSG = (
+_TYPE_MSG = (
     "Got an unsupported type ({}). Dask-ML's PCA only support Dask Arrays or "
     "DataFrames.\n\nTo resolve this issue,\n\n"
     "  * Use Scikit-learn's PCA through `sklearn.decomposition.PCA`  # recommended\n\n"
@@ -198,7 +198,7 @@ class PCA(sklearn.decomposition.PCA):
 
     def fit(self, X, y=None):
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            raise ValueError(TYPE_MSG.format(type(X)))
+            raise ValueError(_TYPE_MSG.format(type(X)))
         self._fit(X)
         return self
 
@@ -409,7 +409,7 @@ class PCA(sklearn.decomposition.PCA):
         """
         # X = check_array(X)
         if isinstance(X, (np.ndarray, pd.DataFrame)):
-            raise ValueError(TYPE_MSG.format(type(X)))
+            raise ValueError(_TYPE_MSG.format(type(X)))
         U, S, V = self._fit(X)
         U = U[:, : self.n_components_]
 

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -360,11 +360,6 @@ def _num_samples(X):
     return result
 
 
-def _copy_attrs(c1, c2, names):
-    for name in names:
-        setattr(c2, name, getattr(c1, name))
-
-
 __all__ = [
     "assert_estimator_equal",
     "check_array",

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -360,6 +360,11 @@ def _num_samples(X):
     return result
 
 
+def _copy_attrs(c1, c2, names):
+    for name in names:
+        setattr(c2, name, getattr(c1, name))
+
+
 __all__ = [
     "assert_estimator_equal",
     "check_array",

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -654,13 +654,13 @@ def test_pca_sparse_input():
     for svd_solver in solver_list:
         pca = dd.PCA(n_components=3, svd_solver=svd_solver)
 
-        assert_raises(TypeError, pca.fit, X)
+        assert_raises(TypeError, pca.fit, X, msg="unsupported type")
 
 
 def test_pca_bad_solver():
     X = np.random.RandomState(0).rand(5, 4)
     pca = dd.PCA(n_components=3, svd_solver="bad_argument")
-    assert_raises(ValueError, pca.fit, X)
+    assert_raises(ValueError, pca.fit, da.from_array(X))
 
 
 # def test_pca_dtype_preservation():
@@ -782,12 +782,12 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
             pca.fit(X)
 
 
-@pytest.mark.parametrize("input_type", [np.array, pd.DataFrame])
+@pytest.mark.parametrize("input_type", [np.array, pd.DataFrame, sp.sparse.csr_matrix])
 def test_pca_sklearn_inputs(input_type):
     Y = input_type(X)
 
     a = dd.PCA()
-    with pytest.raises(ValueError, match="unsupported type"):
+    with pytest.raises(TypeError, match="unsupported type"):
         a.fit(Y)
-    with pytest.raises(ValueError, match="unsupported type"):
+    with pytest.raises(TypeError, match="unsupported type"):
         a.fit_transform(Y)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -26,7 +26,7 @@ with warnings.catch_warnings():
 
 
 iris = datasets.load_iris()
-solver_list = ["full", "randomized", "auto"]
+solver_list = ["full", "randomized", "auto", "tsqr"]
 X = iris.data
 n_samples, n_features = X.shape
 dX = da.from_array(X, chunks=(n_samples // 2, n_features))
@@ -644,17 +644,7 @@ def test_pca_zero_noise_variance_edge_cases():
 
 # removed test_svd_solver_auto, as we don't do that.
 # removed test_deprecation_randomized_pca, as we don't do that
-
-
-def test_pca_sparse_input():
-    X = np.random.RandomState(0).rand(5, 4)
-    X = sp.sparse.csr_matrix(X)
-    assert sp.sparse.issparse(X)
-
-    for svd_solver in solver_list:
-        pca = dd.PCA(n_components=3, svd_solver=svd_solver)
-
-        assert_raises(TypeError, pca.fit, X, msg="unsupported type")
+# removed test_pca_sparse_input: covered by test_pca_sklearn_inputs
 
 
 def test_pca_bad_solver():
@@ -783,7 +773,8 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
 
 
 @pytest.mark.parametrize("input_type", [np.array, pd.DataFrame, sp.sparse.csr_matrix])
-def test_pca_sklearn_inputs(input_type):
+@pytest.mark.parametrize("solver", solver_list)
+def test_pca_sklearn_inputs(input_type, solver):
     Y = input_type(X)
 
     a = dd.PCA()

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -783,17 +783,10 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
 
 
 @pytest.mark.parametrize("input_type", ["array", "dataframe"])
-def test_pca_w_numpy_inputs(input_type):
+def test_pca_sklearn_inputs(input_type):
     a = dd.PCA()
-    b = sd.PCA()
 
     assert isinstance(X, np.ndarray)
     _X = X if input_type != "dataframe" else pd.DataFrame(X)
-    a.fit(_X)
-    b.fit(_X)
-    assert_estimator_equal(a, b)
-
-    Y1 = a.fit_transform(_X)
-    Y2 = b.fit_transform(_X)
-    assert_estimator_equal(a, b)
-    assert_array_almost_equal(Y1, Y2)
+    with pytest.raises(ValueError, match="unsupported type"):
+        a.fit(_X)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -784,11 +784,12 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
 
 @pytest.mark.parametrize("input_type", ["array", "dataframe"])
 def test_pca_sklearn_inputs(input_type):
-    a = dd.PCA()
+    X = np.linspace(0, 1, num=100).reshape(20, 5)
+    if input_type == "dataframe":
+        X = pd.DataFrame(X)
 
-    assert isinstance(X, np.ndarray)
-    _X = X if input_type != "dataframe" else pd.DataFrame(X)
+    a = dd.PCA()
     with pytest.raises(ValueError, match="unsupported type"):
-        a.fit(_X)
+        a.fit(X)
     with pytest.raises(ValueError, match="unsupported type"):
-        a.fit_transform(_X)
+        a.fit_transform(X)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -790,3 +790,5 @@ def test_pca_sklearn_inputs(input_type):
     _X = X if input_type != "dataframe" else pd.DataFrame(X)
     with pytest.raises(ValueError, match="unsupported type"):
         a.fit(_X)
+    with pytest.raises(ValueError, match="unsupported type"):
+        a.fit_transform(_X)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -780,3 +780,20 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
     else:
         with pytest.raises(ValueError, match="n_components is too large"):
             pca.fit(X)
+
+
+@pytest.mark.parametrize("input_type", ["array", "dataframe"])
+def test_pca_w_numpy_inputs(input_type):
+    a = dd.PCA()
+    b = sd.PCA()
+
+    assert isinstance(X, np.ndarray)
+    _X = X if input_type != "dataframe" else pd.DataFrame(X)
+    a.fit(_X)
+    b.fit(_X)
+    assert_estimator_equal(a, b)
+
+    Y1 = a.fit_transform(_X)
+    Y2 = b.fit_transform(_X)
+    assert_estimator_equal(a, b)
+    assert_array_almost_equal(Y1, Y2)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -782,14 +782,12 @@ def test_unknown_shapes_n_components_larger_than_num_rows(solver):
             pca.fit(X)
 
 
-@pytest.mark.parametrize("input_type", ["array", "dataframe"])
+@pytest.mark.parametrize("input_type", [np.array, pd.DataFrame])
 def test_pca_sklearn_inputs(input_type):
-    X = np.linspace(0, 1, num=100).reshape(20, 5)
-    if input_type == "dataframe":
-        X = pd.DataFrame(X)
+    Y = input_type(X)
 
     a = dd.PCA()
     with pytest.raises(ValueError, match="unsupported type"):
-        a.fit(X)
+        a.fit(Y)
     with pytest.raises(ValueError, match="unsupported type"):
-        a.fit_transform(X)
+        a.fit_transform(Y)


### PR DESCRIPTION
**What does this PR implement?**
This PR allows Dask-ML's PCA implementation to work with NumPy arrays and Pandas DataFrames.

This PR closes #578 (well https://github.com/dask/dask-ml/issues/578#issuecomment-548973996).