### PR TITLE
dask-searchcv -> dask-ml in docs (#585)

### DIFF
--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -54,7 +54,7 @@ with Dask's :ref:`joblib backend <joblib>`.
 Flexible Backends
 ^^^^^^^^^^^^^^^^^
 
-Dask-searchcv can use any of the dask schedulers. By default the threaded
+Dask-ml can use any of the dask schedulers. By default the threaded
 scheduler is used, but this can easily be swapped out for the multiprocessing
 or distributed scheduler:
 


### PR DESCRIPTION
Replace dask-searchcv in main dask-ml docs (but left appropriate mention in history).