### PR TITLE
use nanmean and nanvar to comply with sklearn docs

### DIFF
--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -53,10 +53,10 @@ class StandardScaler(sklearn.preprocessing.StandardScaler):
             X = X.values
 
         if self.with_mean:
-            mean_ = X.mean(0)
+            mean_ = X.nanmean(0)
             attributes["mean_"] = mean_
         if self.with_std:
-            var_ = X.var(0)
+            var_ = X.nanvar(0)
             scale_ = var_.copy()
             scale_[scale_ == 0] = 1
             scale_ = da.sqrt(scale_)

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import sklearn.preprocessing
 from dask import compute
+from dask.array import nanmean, nanvar
 from pandas.api.types import is_categorical_dtype
 from scipy import stats
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -53,10 +54,10 @@ class StandardScaler(sklearn.preprocessing.StandardScaler):
             X = X.values
 
         if self.with_mean:
-            mean_ = X.nanmean(0)
+            mean_ = nanmean(X, 0)
             attributes["mean_"] = mean_
         if self.with_std:
-            var_ = X.nanvar(0)
+            var_ = nanvar(X, 0)
             scale_ = var_.copy()
             scale_[scale_ == 0] = 1
             scale_ = da.sqrt(scale_)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -50,17 +50,6 @@ def pandas_df():
 def dask_df(pandas_df):
     return dd.from_pandas(pandas_df, npartitions=5)
 
-@pytest.fixture
-def pandas_nan_df():
-    df = pd.DataFrame(5 * [range(42)]).T.rename(columns=str)
-    df.iloc[0] = np.nan
-
-
-@pytest.fixture
-def dask_nan_df(pandas_df):
-    return dd.from_pandas(pandas_df, npartitions=5)
-
-
 class TestStandardScaler:
     def test_basic(self):
         a = dpp.StandardScaler()
@@ -101,7 +90,10 @@ class TestStandardScaler:
         assert dask.is_dask_collection(result)
         assert_eq_ar(result, X)
 
-    def test_nan(self, dask_nan_df):
+    def test_nan(self, pandas_df):
+        pandas_df = pandas_df.copy()
+        pandas_df.iloc[0] = np.nan
+        dask_nan_df = dd.from_pandas(pandas_df, npartitions=5)
         a = dpp.StandardScaler()
         a.fit(dask_nan_df.values)
         assert np.isnan(a.mean_).sum() == 0


### PR DESCRIPTION
Under the `Notes` section [here](https://ml.dask.org/modules/generated/dask_ml.preprocessing.StandardScaler.html#dask_ml.preprocessing.StandardScaler) it mentions:

> NaNs are treated as missing values: disregarded in fit, and maintained in transform.

To be consistent with these docs I've used `nanmean` and `nanvar` instead of the usual mean and var methods.