### PR TITLE
Fix DummyEncoder.transform error message

### DIFF
--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -657,7 +657,7 @@ class DummyEncoder(BaseEstimator, TransformerMixin):
         if not X.columns.equals(self.columns_):
             raise ValueError(
                 "Columns of 'X' do not match the training "
-                "columns. Got {!r}, expected {!r}".format(X.columns, self.columns)
+                "columns. Got {!r}, expected {!r}".format(X.columns, self.columns_)
             )
         if isinstance(X, pd.DataFrame):
             return pd.get_dummies(X, drop_first=self.drop_first, columns=self.columns)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -404,6 +404,13 @@ class TestDummyEncoder:
         result = de.fit_transform(a)
         assert isinstance(result, dd.DataFrame)
 
+    def test_transform_explicit_columns(self):
+        de = dpp.DummyEncoder(columns=["A", "B", "C", "D"])
+        de.fit(dummy)
+        with pytest.raises(ValueError) as rec:
+            de.transform(dummy.drop("B", axis="columns"))
+        assert rec.match("Columns of 'X' do not match the training")
+
     def test_transform_raises(self):
         de = dpp.DummyEncoder()
         de.fit(dummy)

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -405,7 +405,7 @@ class TestDummyEncoder:
         assert isinstance(result, dd.DataFrame)
 
     def test_transform_explicit_columns(self):
-        de = dpp.DummyEncoder(columns=["A", "B", "C", "D"])
+        de = dpp.DummyEncoder(columns=["A", "B", "C"])
         de.fit(dummy)
         with pytest.raises(ValueError) as rec:
             de.transform(dummy.drop("B", axis="columns"))


### PR DESCRIPTION
I ran into the issue in #357 while using DummyEncoder recently, so I figured I would contribute a small fix for the print statement.

It also adds a test with `columns=...` specified. Would any other tests be useful here?