### PR TITLE
Make GridSearchCV reuse scattered data.

### DIFF
--- a/dask_ml/model_selection/utils.py
+++ b/dask_ml/model_selection/utils.py
@@ -85,7 +85,7 @@ def to_keys(dsk, *args):
             yield x.key
         else:
             assert not is_dask_collection(x)
-            key = "ndarray-" + tokenize(x)
+            key = type(x).__name__ + "-" + tokenize(x)
             dsk[key] = x
             yield key
 

--- a/dask_ml/model_selection/utils.py
+++ b/dask_ml/model_selection/utils.py
@@ -85,7 +85,7 @@ def to_keys(dsk, *args):
             yield x.key
         else:
             assert not is_dask_collection(x)
-            key = "array-" + tokenize(x)
+            key = "ndarray-" + tokenize(x)
             dsk[key] = x
             yield key
 

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import stats
+import pandas as pd
 from sklearn.svm import SVC
 
 from dask.distributed import Client
@@ -22,8 +23,9 @@ def test_search_basic(xy_classification):
 def test_to_keys_numpy_array():
     rng = np.random.RandomState(0)
     arr = rng.randn(20, 30)
+    df = pd.DataFrame(data=arr)
     dsk = {}
-    grid_search_key, = dms.to_keys(dsk, arr)
+    grid_search_keys = list(dms.utils.to_keys(dsk, arr, df))
     with Client() as client:
-        arr_future = client.scatter(arr)
-    assert grid_search_key == arr_future.key
+        data_futures = client.scatter([arr, df])
+    assert grid_search_keys == [f.key for f in data_futures]

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,5 +1,8 @@
+import numpy as np
 from scipy import stats
 from sklearn.svm import SVC
+
+from dask.distributed import Client
 
 import dask_ml.model_selection as dms
 
@@ -14,3 +17,13 @@ def test_search_basic(xy_classification):
     param_dist = {"C": stats.uniform}
     b = dms.RandomizedSearchCV(SVC(kernel="rbf", gamma=0.1), param_dist)
     b.fit(X, y)
+
+
+def test_to_keys_numpy_array():
+    rng = np.random.RandomState(0)
+    arr = rng.randn(20, 30)
+    dsk = {}
+    grid_search_key, = dms.to_keys(dsk, arr)
+    with Client() as client:
+        arr_future = client.scatter(arr)
+    assert grid_search_key == arr_future.key


### PR DESCRIPTION
Fix #516.

Maybe there is a better test? Also could use `type(x).__name__` (rather than hardcoded `ndarray`) as in `client.scatter`: https://github.com/dask/distributed/blob/9b5bf448af478a166069aefc9c0c1354a29ae482/distributed/client.py#L1930