### PR TITLE
DOC: provide methods to circumvent unknown chunk sizes

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -7,11 +7,11 @@ from time import time
 
 import dask
 import dask.array as da
+import dask.dataframe as dd
 import numpy as np
 import scipy.stats
 import toolz
 from dask.distributed import Future, default_client, futures_of, wait
-import dask.dataframe as dd
 from distributed.utils import log_errors
 from sklearn.base import clone
 from sklearn.metrics import check_scoring

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -8,7 +8,6 @@ from time import time
 import dask
 import dask.array as da
 import numpy as np
-import pandas as pd
 import scipy.stats
 import toolz
 from dask.distributed import Future, default_client, futures_of, wait

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -448,6 +448,7 @@ class BaseIncrementalSearchCV(ParallelPostFit):
                 )
             )
 
+        # Make sure dask arrays are passed so error on unknown chunk size is raised
         if isinstance(X, dd.DataFrame):
             X = X.to_dask_array()
         if isinstance(y, (dd.DataFrame, dd.Series)):

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -158,10 +158,6 @@ def check_array(
         elif shape == 1:
             shape = min(10, shape[0])
 
-        if accept_unknown_chunks and np.isnan(shape).any():
-            idx = np.isnan(shape)
-            shape = tuple(s if not np.isnan(s) else 10 for s in shape)
-
         sample = np.ones(shape=shape, dtype=array.dtype)
         sk_validation.check_array(sample, *args, **kwargs)
         return array

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -129,7 +129,10 @@ def check_array(
         if not accept_unknown_chunks:
             if np.isnan(array.shape[0]):
                 raise TypeError(
-                    "Cannot operate on Dask array with unknown chunk sizes."
+                    "Cannot operate on Dask array with unknown chunk sizes. "
+                    "Use the following the compute chunk sizes:\n\n"
+                    "   >>> X.compute_chunk_sizes()  # if Dask.Array\n"
+                    "   >>> ddf.to_dask_array(lengths=True)  # if Dask.Dataframe"
                 )
         if not accept_multiple_blocks and array.ndim > 1:
             if len(array.chunks[1]) > 1:
@@ -154,6 +157,10 @@ def check_array(
             shape = (min(10, shape[0]), shape[1])
         elif shape == 1:
             shape = min(10, shape[0])
+
+        if accept_unknown_chunks and np.isnan(shape).any():
+            idx = np.isnan(shape)
+            shape = tuple(s if not np.isnan(s) else 10 for s in shape)
 
         sample = np.ones(shape=shape, dtype=array.dtype)
         sk_validation.check_array(sample, *args, **kwargs)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -1,14 +1,14 @@
-import random
 import itertools
+import random
 
 import dask.array as da
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
 import scipy
 import toolz
 from dask.distributed import Future
-import dask.dataframe as dd
 from distributed.utils_test import cluster, gen_cluster, loop  # noqa: F401
 from sklearn.base import clone
 from sklearn.cluster import MiniBatchKMeans

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -237,9 +237,10 @@ def _test_search_basic(decay_rate, input_type, memory, c, s, a, b):
     if memory == "distributed" and input_type == "dataframe":
         with pytest.raises(TypeError, match=r"to_dask_array\(lengths=True\)"):
             yield search.fit(X, y, classes=[0, 1])
-        return  # skip the rest of the test
-    else:
-        yield search.fit(X, y, classes=[0, 1])
+        return  # exit the test; some test difficulties with below statements
+        #  yield X.to_dask_array(lengths=True)
+        #  yield y.to_dask_array(lengths=True)
+    yield search.fit(X, y, classes=[0, 1])
 
     assert search.history_
     for d in search.history_:

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -18,7 +18,6 @@ from sklearn.utils import check_random_state
 from tornado import gen
 
 from dask_ml.datasets import make_classification
-from sklearn.datasets import make_classification as sk_make_classification
 from dask_ml.model_selection import IncrementalSearchCV
 from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 from dask_ml.model_selection.utils_test import LinearFunction, _MaybeLinearFunction


### PR DESCRIPTION
**What does this PR implement?**
It makes the conversion to Dask Array more clear. This reflects the documentation in https://github.com/dask/dask/pull/4516

**Reference issues/PRs**
* The motivation is https://github.com/dask/dask-ml/issues/628. I started to support Dataframes in `IncrementalSearchCV`. However, I'm not sure how feasible this is: `train_test_split` requires known chunk sizes.