### PR TITLE
DOC: better link to dask-examples

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -4,9 +4,17 @@
 Examples
 ========
 
-`dask-examples`_ contains a set of runnable examples. The `machine learning overview`_
-gives an overview and many specific examples are listed in the table of contents on
-the main page.
+`dask-examples`_ contains a set of runnable examples:
 
+* The `basic machine learning example`_ gives an overview and many specific
+  examples are listed in the table of contents on the main page.
+* The `machine learning section`_ gives more examples of using Dask for machine
+  learning with other libraries or for particular machine learning use cases.
+
+Dask-ML can be used with XGBoost, PyTorch and TPOT, and can be used for
+hyperparameter optimization. These are some of the examples that
+`dask-examples`_ includes.
+
+.. _machine learning section: https://examples.dask.org/#machine-learning
 .. _dask-examples: https://examples.dask.org
-.. _machine learning overview: https://examples.dask.org/machine-learning.html
+.. _basic machine learning example: https://examples.dask.org/machine-learning.html

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -19,11 +19,11 @@ block of a Dask Array to the underlying estimator's ``partial_fit`` method.
 
 .. note::
 
-   :class:`dask_ml.wrappers.Incremetnal` currently does not work well with
+   :class:`dask_ml.wrappers.Incremental` currently does not work well with
    hyper-parameter optimization like :class:`sklearn.model_selection.GridSearchCV`.
    If you need to do hyper-parameter optimization on larger-than-memory datasets,
-   we recommend :class:`dask_ml.model_selection.IncrementalSearch`. See
-   :ref:`hyperparameter.incremental` for an introduction.
+   we recommend :class:`dask_ml.model_selection.IncrementalSearchCV`. See
+   ":ref:`hyperparameter.incremental`" for an introduction.
 
 .. _incremental.blockwise-metaestimator:
 
@@ -113,5 +113,5 @@ If necessary, the actual estimator trained is available as ``Incremental.estimat
 Incremental Learning and Hyper-parameter Optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See :ref:`hyperparameter.incremental` for more on how to do hyperparameter optimization on
+See ":ref:`hyperparameter.incremental`" for more on how to do hyperparameter optimization on
 larger than memory datasets.

--- a/docs/source/xgboost.rst
+++ b/docs/source/xgboost.rst
@@ -60,6 +60,6 @@ continues on as normal.
 This work was a collaboration with XGBoost and SKLearn maintainers.  See
 relevant GitHub issue here: `dmlc/xgboost #2032 <https://github.com/dmlc/xgboost/issues/2032>`_
 
-- :doc:`examples/xgboost`
+See the ":doc:`Dask-ML examples <examples>`" for an example usage.
 
 .. _XGBoost: https://xgboost.readthedocs.io/


### PR DESCRIPTION
**What does this PR implement?**
* Links to "machine learning" section of dask-examples
* Small fixes (typos, broken links)

**References issues/PRs**
* This closes #641.
* This PR depends on https://github.com/dask/dask-examples/pull/144.