### PR TITLE
MAINT: provide potential solutions in warning on "dataframes not accepted"

### DIFF
--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -174,8 +174,12 @@ def check_array(
 
     elif isinstance(array, dd.DataFrame):
         if not accept_dask_dataframe:
-            raise TypeError("This estimator does not support dask dataframes.")
-        # TODO: sample?
+            raise TypeError(
+                "This estimator does not support dask dataframes. "
+                "This might be resolved with one of\n\n"
+                "    1. ddf.to_dask_array()\n"
+                "    2. ddf.to_dask_array(lengths=True)\n"
+            )
         return array
     elif isinstance(array, pd.DataFrame) and preserve_pandas_dataframe:
         # TODO: validation?

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -180,6 +180,7 @@ def check_array(
                 "    1. ddf.to_dask_array()\n"
                 "    2. ddf.to_dask_array(lengths=True)\n"
             )
+        # TODO: sample?
         return array
     elif isinstance(array, pd.DataFrame) and preserve_pandas_dataframe:
         # TODO: validation?

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -177,8 +177,9 @@ def check_array(
             raise TypeError(
                 "This estimator does not support dask dataframes. "
                 "This might be resolved with one of\n\n"
-                "    1. ddf.to_dask_array()\n"
-                "    2. ddf.to_dask_array(lengths=True)\n"
+                "    1. ddf.to_dask_array(lengths=True)\n"
+                "    2. ddf.to_dask_array()  # may cause other issues because "
+                "of unknown chunk sizes"
             )
         # TODO: sample?
         return array

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -177,13 +177,14 @@ def test_lr_score():
     lr.fit(X, X)
     assert lr.score(X, X) == pytest.approx(1, 0.001)
 
-def test_dataframe_warns_about_chunks():
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_dataframe_warns_about_chunks(fit_intercept):
     rng = np.random.RandomState(42)
     n, d = 20, 5
-    kwargs = dict(npartitions=5)
+    kwargs = dict(npartitions=4)
     X = dd.from_pandas(pd.DataFrame(rng.uniform(size=(n, d))), **kwargs)
     y = dd.from_pandas(pd.Series(rng.choice(2, size=n)), **kwargs)
-    clf = LogisticRegression(fit_intercept=True)
+    clf = LogisticRegression(fit_intercept=fit_intercept)
     msg = "does not support dask dataframes.*might be resolved with"
     with pytest.raises(TypeError, match=msg):
         clf.fit(X, y)

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -177,6 +177,7 @@ def test_lr_score():
     lr.fit(X, X)
     assert lr.score(X, X) == pytest.approx(1, 0.001)
 
+
 @pytest.mark.parametrize("fit_intercept", [True, False])
 def test_dataframe_warns_about_chunks(fit_intercept):
     rng = np.random.RandomState(42)

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -176,3 +176,17 @@ def test_lr_score():
     lr = LinearRegression()
     lr.fit(X, X)
     assert lr.score(X, X) == pytest.approx(1, 0.001)
+
+def test_dataframe_warns_about_chunks():
+    rng = np.random.RandomState(42)
+    n, d = 20, 5
+    kwargs = dict(npartitions=5)
+    X = dd.from_pandas(pd.DataFrame(rng.uniform(size=(n, d))), **kwargs)
+    y = dd.from_pandas(pd.Series(rng.choice(2, size=n)), **kwargs)
+    clf = LogisticRegression(fit_intercept=True)
+    msg = "does not support dask dataframes.*might be resolved with"
+    with pytest.raises(TypeError, match=msg):
+        clf.fit(X, y)
+    clf.fit(X.values, y.values)
+    clf.fit(X.to_dask_array(), y.to_dask_array())
+    clf.fit(X.to_dask_array(lengths=True), y.to_dask_array(lengths=True))


### PR DESCRIPTION
**What does this PR implement?**
It modifies message of the `TypeError` in utils.py if Dask Dataframes are not accepted. It suggests code that may resolve the issue.

I only provide `ddf.to_dask_array(...)` solutions because Pandas recommends using `to_numpy` instead of `values`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.values.html

**Reference issues/PRs**
The motivation is https://github.com/dask/dask-ml/issues/84. I tried to get the code to fail with unknown chunk sizes, but the code worked. Instead, I decided to modify the message about not accepting Dask DataFrames with a potential solution.

(note: I make sure `fit_intercept in [True, False]` because of https://github.com/dask/dask-ml/issues/84#issuecomment-342526205).