### PR TITLE
Import ABC from collections.abc for Python 3 compatibility.

### DIFF
--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 import functools
 import logging
-from collections import Sequence
+from collections.abc import Sequence
 from multiprocessing import cpu_count
 from numbers import Integral
 from timeit import default_timer as tic


### PR DESCRIPTION
Fixes #655 