### PR TITLE
MAINT: show errors while scoring models in model selection

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -99,10 +99,12 @@ def _partial_fit(model_and_meta, X, y, fit_params):
 def _score(model_and_meta, X, y, scorer):
     start = time()
     model, meta = model_and_meta
-    if scorer:
-        score = scorer(model, X, y)
-    else:
-        score = model.score(X, y)
+
+    with log_errors():
+        if scorer:
+            score = scorer(model, X, y)
+        else:
+            score = model.score(X, y)
 
     meta = dict(meta)
     meta.update(score=score, score_time=time() - start)


### PR DESCRIPTION
**What does this PR implement?**
In #670 I more clearly showed errors while initializing models. This PR does the same thing, but while scoring models.

**Reference issues/PRs**
This PR is a follow up to #670 (ideally this commit would be in that PR).