### PR TITLE
DOC: add install pre-commit code

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -101,10 +101,15 @@ You can still use all the usual pytest command-line options in addition to those
 Pre-Commit Hooks
 ~~~~~~~~~~~~~~~~
 
-Install the `pre commit <https://github.com/pre-commit/pre-commit>`_ tool. Then, from the
-root of the ``dask-ml`` repository, run ``pre-commit install`` to install a few plugins
-like black, isort, and flake8. These tools will automatically be run on each commit. You
-can skip the checks with ``git commit --no-verify``.
+Install and build the `pre commit <https://github.com/pre-commit/pre-commit>`_ tool as:
+
+.. code-block:: none
+
+    pip install pre-commit
+    pre-commit install
+
+to install a few plugins like black, isort, and flake8. These tools will automatically
+be run on each commit. You can skip the checks with ``git commit --no-verify``.
 
 Conventions
 ~~~~~~~~~~~

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -105,7 +105,7 @@ Install and build the `pre commit <https://github.com/pre-commit/pre-commit>`_ t
 
 .. code-block:: none
 
-    pip install pre-commit
+    python -m pip install pre-commit
     pre-commit install
 
 to install a few plugins like black, isort, and flake8. These tools will automatically


### PR DESCRIPTION
Added more verbose processing of installing and building pre-commit to save people clicking through to the pre-commit project to see how to install it.

Removed the instructions of going to the dask-ml root as I assume people are working in there if they are running things like https://ml.dask.org/contributing.html#creating-an-environment

I also looked at the xarray docs for inspiration http://xarray.pydata.org/en/stable/contributing.html#code-formatting