### PR TITLE
datasets.make_regression as Dask dataframe and series

### DIFF
--- a/dask_ml/datasets.py
+++ b/dask_ml/datasets.py
@@ -390,7 +390,7 @@ def random_date(start, end):
 
 
 def return_dataframes(func):
-    """Wraps a function that returns a tuple of Dask arrays (X, y) to return 
+    """Wraps a function that returns a tuple of Dask arrays (X, y) to return
     a tuple of Dask dataframe and series (X_df, y_series).
     """
 
@@ -406,8 +406,8 @@ def return_dataframes(func):
         y : Dask Series of shape [n_samples] or [n_samples, n_targets]
             The output values.
         """
-        random_state, chunks = map(kwargs.get, ('random_state', 'chunks'))
-        dates = kwargs.pop('dates', None)
+        random_state, chunks = map(kwargs.get, ("random_state", "chunks"))
+        dates = kwargs.pop("dates", None)
 
         X_array, y_array = func(*args, **kwargs)
 
@@ -430,7 +430,9 @@ def return_dataframes(func):
                 axis=1,
             )
         return X_df, y_series
+
     return wrapper
+
 
 make_classification_df = return_dataframes(make_classification)
 make_regression_df = return_dataframes(make_regression)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -63,7 +63,6 @@ def test_deterministic(generator, scheduler):
     assert_eq(a, b)
     assert_eq(t, u)
 
-
 def test_make_classification_df():
     X_df, y_series = dask_ml.datasets.make_classification_df(
         n_samples=100,
@@ -77,6 +76,62 @@ def test_make_classification_df():
     assert y_series is not None
     assert "date" in X_df.columns
     assert len(X_df.columns) == 6
+    assert len(X_df) == 100
+    assert len(y_series) == 100
+    assert isinstance(y_series, dask.dataframe.core.Series)
+
+def test_make_classification_df_missing_kwargs():
+    with pytest.raises(ValueError):
+        X_df, y_series = dask_ml.datasets.make_classification_df(
+            n_samples=100,
+            n_features=5,
+        )
+
+def test_make_classification_df_without_dates():
+    X_df, y_series = dask_ml.datasets.make_classification_df(
+        n_samples=100,
+        n_features=5,
+        random_state=123,
+        chunks=100,
+    )
+
+    assert X_df is not None
+    assert y_series is not None
+    assert "date" not in X_df.columns
+    assert len(X_df.columns) == 5
+    assert len(X_df) == 100
+    assert len(y_series) == 100
+    assert isinstance(y_series, dask.dataframe.core.Series)
+
+def test_make_regression_df():
+    X_df, y_series = dask_ml.datasets.make_regression_df(
+        n_samples=100,
+        n_features=5,
+        random_state=123,
+        chunks=100,
+        dates=(date(2014, 1, 1), date(2015, 1, 1)),
+    )
+
+    assert X_df is not None
+    assert y_series is not None
+    assert "date" in X_df.columns
+    assert len(X_df.columns) == 6
+    assert len(X_df) == 100
+    assert len(y_series) == 100
+    assert isinstance(y_series, dask.dataframe.core.Series)
+
+def test_make_regression_df_without_dates():
+    X_df, y_series = dask_ml.datasets.make_regression_df(
+        n_samples=100,
+        n_features=5,
+        random_state=123,
+        chunks=100,
+    )
+
+    assert X_df is not None
+    assert y_series is not None
+    assert "date" not in X_df.columns
+    assert len(X_df.columns) == 5
     assert len(X_df) == 100
     assert len(y_series) == 100
     assert isinstance(y_series, dask.dataframe.core.Series)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -63,6 +63,7 @@ def test_deterministic(generator, scheduler):
     assert_eq(a, b)
     assert_eq(t, u)
 
+
 def test_make_classification_df():
     X_df, y_series = dask_ml.datasets.make_classification_df(
         n_samples=100,
@@ -80,19 +81,17 @@ def test_make_classification_df():
     assert len(y_series) == 100
     assert isinstance(y_series, dask.dataframe.core.Series)
 
+
 def test_make_classification_df_missing_kwargs():
     with pytest.raises(ValueError):
         X_df, y_series = dask_ml.datasets.make_classification_df(
-            n_samples=100,
-            n_features=5,
+            n_samples=100, n_features=5,
         )
+
 
 def test_make_classification_df_without_dates():
     X_df, y_series = dask_ml.datasets.make_classification_df(
-        n_samples=100,
-        n_features=5,
-        random_state=123,
-        chunks=100,
+        n_samples=100, n_features=5, random_state=123, chunks=100,
     )
 
     assert X_df is not None
@@ -102,6 +101,7 @@ def test_make_classification_df_without_dates():
     assert len(X_df) == 100
     assert len(y_series) == 100
     assert isinstance(y_series, dask.dataframe.core.Series)
+
 
 def test_make_regression_df():
     X_df, y_series = dask_ml.datasets.make_regression_df(
@@ -120,12 +120,10 @@ def test_make_regression_df():
     assert len(y_series) == 100
     assert isinstance(y_series, dask.dataframe.core.Series)
 
+
 def test_make_regression_df_without_dates():
     X_df, y_series = dask_ml.datasets.make_regression_df(
-        n_samples=100,
-        n_features=5,
-        random_state=123,
-        chunks=100,
+        n_samples=100, n_features=5, random_state=123, chunks=100,
     )
 
     assert X_df is not None


### PR DESCRIPTION
- Added `return_dataframes` wrapper to repackage Xs and ys
- Create `make_regression_df` using wrapper
- Refactored `make_classification_df` to reuse wrapper