### PR TITLE
Docs: [Issue/700]: Add datasets to API documentation

### DIFF
--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -264,3 +264,20 @@ Classification Metrics
 
    train
    predict
+
+:mod:`dask_ml.datasets`: Datasets
+======================================================
+
+dask-ml provides some utilities for generating toy datasets.
+
+.. automodule:: dask_ml.datasets
+
+.. currentmodule:: dask_ml.datasets
+
+.. autosummary::
+   :toctree: generated/
+
+   make_counts
+   make_blobs
+   make_regression
+   make_classification_df

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -280,4 +280,5 @@ dask-ml provides some utilities for generating toy datasets.
    make_counts
    make_blobs
    make_regression
+   make_classification
    make_classification_df


### PR DESCRIPTION
Issue reference : https://github.com/dask/dask-ml/issues/700

This PR:
- includes dask_ml.datasets module to the API documentation

Comment:
I see a make_classification() function that is not documented. I didn't include it in this PR for this reason. Can you confirm?