### PR TITLE
Count vectorizer (with Actors)

### DIFF
--- a/dask_ml/feature_extraction/text.py
+++ b/dask_ml/feature_extraction/text.py
@@ -119,16 +119,19 @@ class FeatureHasher(_BaseHasher, sklearn.feature_extraction.text.FeatureHasher):
 class CountVectorizer(sklearn.feature_extraction.text.CountVectorizer):
     """Convert a collection of text documents to a matrix of token counts
 
-    .. note::
-
-       This implementation requires an active :class:`distributed.Client`.
-
     Notes
     -----
     When a vocabulary isn't provided, ``fit_transform`` requires two
     passes over the dataset: one to learn the vocabulary and a second
     to transform the data. Consider persisting the data if it fits
-    in (distributed) memory.
+    in (distributed) memory prior to calling ``fit`` or ``transform``
+    when not providing a ``vocabulary``.
+
+    Additionally, this implementation benefits from having
+    an active ``dask.distributed.Client``, even on a single machine.
+    When a client is present, the learned ``vocabulary`` is persisted
+    in distributed memory, which saves some recompuation and redundant
+    communication.
 
     See Also
     --------
@@ -136,6 +139,9 @@ class CountVectorizer(sklearn.feature_extraction.text.CountVectorizer):
 
     Examples
     --------
+    The Dask-ML implementation currently requires that ``raw_documents``
+    is a :class:`dask.bag.Bag` of documents (lists of strings).
+
     >>> from dask_ml.feature_extraction.text import CountVectorizer
     >>> import dask.bag as db
     >>> from distributed import Client

--- a/dask_ml/feature_extraction/text.py
+++ b/dask_ml/feature_extraction/text.py
@@ -215,7 +215,7 @@ class CountVectorizer(sklearn.feature_extraction.text.CountVectorizer):
             else:
                 vocabulary_for_transform = vocabulary
 
-        n_features = vocabulary_length(vocabulary)
+        n_features = vocabulary_length(vocabulary_for_transform)
         transformed = raw_documents.map_partitions(
             _count_vectorizer_transform, vocabulary_for_transform, params
         )
@@ -239,7 +239,7 @@ def vocabulary_length(vocabulary):
     elif isinstance(vocabulary, Delayed):
         try:
             return len(vocabulary)
-        except ValueError:
+        except TypeError:
             return len(vocabulary.compute())
     elif isinstance(vocabulary, distributed.Future):
         client = get_client()

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -96,7 +96,7 @@ def assert_estimator_equal(left, right, exclude=None, **kwargs):
     for attr in left_attrs2:
         l = getattr(left, attr)
         r = getattr(right, attr)
-        _assert_eq(l, r, **kwargs)
+        _assert_eq(l, r, name=attr, **kwargs)
 
 
 def check_array(
@@ -193,7 +193,7 @@ def check_array(
         return sk_validation.check_array(array, *args, **kwargs)
 
 
-def _assert_eq(l, r, **kwargs):
+def _assert_eq(l, r, name=None, **kwargs):
     array_types = (np.ndarray, da.Array)
     frame_types = (pd.core.generic.NDFrame, dd._Frame)
     if isinstance(l, array_types):
@@ -206,7 +206,7 @@ def _assert_eq(l, r, **kwargs):
         for a, b in zip(l, r):
             _assert_eq(a, b, **kwargs)
     else:
-        assert l == r
+        assert l == r, (name, l, r)
 
 
 def check_random_state(random_state):

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -176,10 +176,11 @@ with Dask Arrays or DataFrames.
    :toctree: generated/
    :template: class.rst
 
+   feature_extraction.text.CountVectorizer
    feature_extraction.text.HashingVectorizer
    feature_extraction.text.FeatureHasher
 
-   
+
 :mod:`dask_ml.compose`: Composite Estimators
 ============================================
 

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -107,3 +107,17 @@ def test_correct_meta():
     assert scipy.sparse.issparse(result._meta)
     assert result._meta.dtype == "float64"
     assert result._meta.shape == (0, 0)
+
+
+def test_count_vectorizer():
+    # TODO: gen_cluster, pickle futures, issue.
+    from distributed import Client
+
+    with Client():
+        m1 = dask_ml.feature_extraction.text.CountVectorizer()
+        m2 = sklearn.feature_extraction.text.CountVectorizer()
+        b = db.from_sequence(JUNK_FOOD_DOCS, npartitions=2)
+        m1.fit(b)
+        m2.fit(b)
+
+        assert_estimator_equal(m1, m2, exclude={"vocabulary_actor_", "stop_words_"})

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -113,7 +113,7 @@ def test_correct_meta():
 def test_count_vectorizer(use_actors):
     # TODO: gen_cluster, pickle futures, issue.
     m1 = sklearn.feature_extraction.text.CountVectorizer()
-    m2 = dask_ml.feature_extraction.text.CountVectorizer()
+    m2 = dask_ml.feature_extraction.text.CountVectorizer(use_actors=use_actors)
     b = db.from_sequence(JUNK_FOOD_DOCS, npartitions=2)
     m1.fit(b.compute())
 

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -109,15 +109,15 @@ def test_correct_meta():
     assert result._meta.shape == (0, 0)
 
 
-@pytest.mark.parametrize("as_distributed", [True, False])
-def test_count_vectorizer(as_distributed):
+@pytest.mark.parametrize("use_actors", [True, False])
+def test_count_vectorizer(use_actors):
     # TODO: gen_cluster, pickle futures, issue.
     m1 = sklearn.feature_extraction.text.CountVectorizer()
     m2 = dask_ml.feature_extraction.text.CountVectorizer()
     b = db.from_sequence(JUNK_FOOD_DOCS, npartitions=2)
     m1.fit(b.compute())
 
-    if as_distributed:
+    if use_actors:
         from distributed import Client
 
         with Client():

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -111,9 +111,9 @@ def test_correct_meta():
     assert result._meta.shape == (0, 0)
 
 
-@pytest.mark.parametrize("use_actors", [True, False])
 @pytest.mark.parametrize("give_vocabulary", [True, False])
-def test_count_vectorizer(use_actors, give_vocabulary):
+@pytest.mark.parametrize("distributed", [True, False])
+def test_count_vectorizer(give_vocabulary, distributed):
     m1 = sklearn.feature_extraction.text.CountVectorizer()
     b = db.from_sequence(JUNK_FOOD_DOCS, npartitions=2)
     r1 = m1.fit_transform(JUNK_FOOD_DOCS)
@@ -125,11 +125,9 @@ def test_count_vectorizer(use_actors, give_vocabulary):
     else:
         vocabulary = None
 
-    m2 = dask_ml.feature_extraction.text.CountVectorizer(
-        use_actors=use_actors, vocabulary=vocabulary
-    )
+    m2 = dask_ml.feature_extraction.text.CountVectorizer(vocabulary=vocabulary)
 
-    if use_actors:
+    if distributed:
         from distributed import Client
 
         client = Client()  # noqa

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -9,7 +9,7 @@ import sklearn.feature_extraction.text
 from distributed import Client
 
 import dask_ml.feature_extraction.text
-from dask_ml._compat import nullcontext
+from dask_ml._compat import dummy_context
 from dask_ml.utils import assert_estimator_equal
 
 JUNK_FOOD_DOCS = (
@@ -130,7 +130,7 @@ def test_count_vectorizer(give_vocabulary, distributed):
     if distributed:
         client = Client()  # noqa
     else:
-        client = nullcontext()
+        client = dummy_context()
 
     if give_vocabulary:
         r2 = m2.transform(b)

--- a/tests/feature_extraction/test_text.py
+++ b/tests/feature_extraction/test_text.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import dask.array as da
 import dask.bag as db
 import dask.dataframe as dd
@@ -11,6 +9,7 @@ import sklearn.feature_extraction.text
 from distributed import Client
 
 import dask_ml.feature_extraction.text
+from dask_ml._compat import nullcontext
 from dask_ml.utils import assert_estimator_equal
 
 JUNK_FOOD_DOCS = (
@@ -131,7 +130,7 @@ def test_count_vectorizer(give_vocabulary, distributed):
     if distributed:
         client = Client()  # noqa
     else:
-        client = contextlib.nullcontext()
+        client = nullcontext()
 
     if give_vocabulary:
         r2 = m2.transform(b)


### PR DESCRIPTION
This has an implementation of CountVectorizer.

The primary difficulty is learning the vocabulary from the data. The basic idea is to just use scikit-learn's CountVectorizer on each partition of a bag. That'll give us a list of vocabularies (dictionaries) that we need to merge.

A naive implementation would just pass the `vocabularies` around as a dictionaries in the task graph. This isn't great since these can get pretty large. For the news dataset, scikit-learn learns a vocabulary that's 18 MB.

I've prototyped something using distributed's Actors (cc @mrocklin if you're interested in seeing them in use). Timings:

Actors? | fit | compute |
------- | --- | ------- |
Yes | 2.3 | 3.4     |
No | 5.2 | 4.2

I'll probably spend a bit more time to make this work without actors again. Regardless, I'll be writing up an example / blog post.

Closes https://github.com/dask/dask-ml/issues/689