### PR TITLE
Add a 'decision_function()' method to the 'LogisticRegression' class.

### DIFF
--- a/dask_ml/linear_model/glm.py
+++ b/dask_ml/linear_model/glm.py
@@ -208,6 +208,7 @@ class LogisticRegression(_GLM):
             >>> X, y = make_classification()
             >>> lr = LogisticRegression()
             >>> lr.fit(X, y)
+            >>> lr.decision_function(X)
             >>> lr.predict(X)
             >>> lr.predict_proba(X)
             >>> lr.score(X, y)"""
@@ -217,6 +218,21 @@ class LogisticRegression(_GLM):
     @property
     def family(self):
         return families.Logistic
+
+    def decision_function(self, X):
+        """Predict confidence scores for samples in X.
+
+        Parameters
+        ----------
+        X : array-like, shape = [n_samples, n_features]
+
+        Returns
+        -------
+        T : array-like, shape = [n_samples, n_classes]
+            The probability of the sample for each class in the model.
+        """
+        X_ = self._check_array(X)
+        return dot(X_, self._coef)
 
     def predict(self, X):
         """Predict class labels for samples in X.
@@ -244,8 +260,7 @@ class LogisticRegression(_GLM):
         T : array-like, shape = [n_samples, n_classes]
             The probability of the sample for each class in the model.
         """
-        X_ = self._check_array(X)
-        return sigmoid(dot(X_, self._coef))
+        return sigmoid(self.decision_function(X))
 
     def score(self, X, y):
         """The mean accuracy on the given data and labels

--- a/dask_ml/linear_model/glm.py
+++ b/dask_ml/linear_model/glm.py
@@ -229,7 +229,7 @@ class LogisticRegression(_GLM):
         Returns
         -------
         T : array-like, shape = [n_samples, n_classes]
-            The probability of the sample for each class in the model.
+            The confidence score of the sample for each class in the model.
         """
         X_ = self._check_array(X)
         return dot(X_, self._coef)

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -89,6 +89,7 @@ def test_big(fit_intercept):
     X, y = make_classification(chunks=50)
     lr = LogisticRegression(fit_intercept=fit_intercept)
     lr.fit(X, y)
+    lr.decision_function(X)
     lr.predict(X)
     lr.predict_proba(X)
     if fit_intercept:


### PR DESCRIPTION
I noticed that the `dask_ml.linear_model.LogisticRegression` class lacked a `decision_function()` method like is implemented in the corresponding [scikit-learn API](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression.decision_function).

This PR adds a `decision_function()` method and updates one corresponding test.