### PR TITLE
Update svd tests for svd_flip

### DIFF
--- a/ci/environment-3.6.yaml
+++ b/ci/environment-3.6.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black
+  - black==19.10b0
   - coverage
   - dask ==2.4.0
   - dask-glm >=0.2.0

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black
+  - black==19.10b0
   - coverage
   - codecov
   - dask

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - black
+  - black==19.10b0
   - coverage
   - codecov
   - dask

--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -21,6 +21,7 @@ SK_024 = SK_VERSION >= packaging.version.parse("0.24.0.dev0")
 DASK_240 = DASK_VERSION >= packaging.version.parse("2.4.0")
 DASK_2130 = DASK_VERSION >= packaging.version.parse("2.13.0")
 DASK_2_20_0 = DASK_VERSION >= packaging.version.parse("2.20.0")
+DASK_2_26_0 = DASK_VERSION >= packaging.version.parse("2.26.0")
 DISTRIBUTED_2_5_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.5.0")
 DISTRIBUTED_2_11_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.10.0")  # dev
 WINDOWS = os.name == "nt"

--- a/dask_ml/_partial.py
+++ b/dask_ml/_partial.py
@@ -28,7 +28,7 @@ def fit(
     assume_equal_chunks=False,
     **kwargs
 ):
-    """ Fit scikit learn model against dask arrays
+    """Fit scikit learn model against dask arrays
 
     Model must support the ``partial_fit`` interface for online or batch
     learning.
@@ -164,7 +164,7 @@ def _predict(model, x):
 
 
 def predict(model, x):
-    """ Predict with a scikit learn model
+    """Predict with a scikit learn model
 
     Parameters
     ----------

--- a/dask_ml/decomposition/incremental_pca.py
+++ b/dask_ml/decomposition/incremental_pca.py
@@ -322,7 +322,10 @@ class IncrementalPCA(pca.PCA):
         # The following part is modified so that it can fit to large dask-array
         solver = self._get_solver(X, self.n_components_)
         if solver in {"full", "tsqr"}:
-            U, S, V = linalg.svd(X)
+            if DASK_2_26_0:
+                U, S, V = linalg.svd(X, coerce_signs=False)
+            else:
+                U, S, V = linalg.svd(X)
             # manually implement full_matrix=False
             if V.shape[0] > len(S):
                 V = V[: len(S)]

--- a/dask_ml/decomposition/incremental_pca.py
+++ b/dask_ml/decomposition/incremental_pca.py
@@ -12,6 +12,7 @@ from scipy import sparse
 from sklearn.utils import gen_batches
 from sklearn.utils.validation import check_random_state
 
+from .._compat import DASK_2_26_0
 from .._utils import draw_seed
 from ..utils import _svd_flip_copy, check_array
 from . import pca
@@ -332,9 +333,18 @@ class IncrementalPCA(pca.PCA):
             random_state = check_random_state(self.random_state)
             seed = draw_seed(random_state, np.iinfo("int32").max)
             n_power_iter = self.iterated_power
-            U, S, V = linalg.svd_compressed(
-                X, self.n_components_, n_power_iter=n_power_iter, seed=seed
-            )
+            if DASK_2_26_0:
+                U, S, V = linalg.svd_compressed(
+                    X,
+                    self.n_components_,
+                    n_power_iter=n_power_iter,
+                    seed=seed,
+                    coerce_signs=False,
+                )
+            else:
+                U, S, V = linalg.svd_compressed(
+                    X, self.n_components_, n_power_iter=n_power_iter, seed=seed
+                )
         U, V = svd_flip(U, V)
         explained_variance = S ** 2 / (n_total_samples - 1)
         components, singular_values = V, S

--- a/dask_ml/decomposition/truncated_svd.py
+++ b/dask_ml/decomposition/truncated_svd.py
@@ -2,6 +2,7 @@ import dask.array as da
 from dask import compute
 from sklearn.base import BaseEstimator, TransformerMixin
 
+from .._compat import DASK_2_26_0
 from ..utils import svd_flip
 
 
@@ -171,7 +172,8 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
             u, s, v = da.linalg.svd_compressed(
                 X, self.n_components, self.n_iter, seed=self.random_state
             )
-        u, v = svd_flip(u, v)
+        if not DASK_2_26_0:
+            u, v = svd_flip(u, v)
 
         X_transformed = u * s
         explained_var = X_transformed.var(axis=0)

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -211,7 +211,7 @@ async def _fit(
     order = []
 
     def get_futures(partial_fit_calls):
-        """ Policy to get training data futures
+        """Policy to get training data futures
 
         Currently we compute once, and then keep in memory.
         Presumably in the future we'll want to let data drop and recompute.
@@ -350,7 +350,7 @@ async def fit(
     verbose: Union[bool, int] = False,
     prefix="",
 ):
-    """ Find a good model and search among a space of hyper-parameters
+    """Find a good model and search among a space of hyper-parameters
 
     This does a hyper-parameter search by creating many models and then fitting
     them incrementally on batches of data and reducing the number of models based

--- a/dask_ml/model_selection/utils_test.py
+++ b/dask_ml/model_selection/utils_test.py
@@ -177,7 +177,7 @@ class CheckingClassifier(BaseEstimator, ClassifierMixin):
             for key, value in fit_params.items():
                 assert len(value) == len(X), (
                     "Fit parameter %s has length"
-                    "%d; expected %d." % (key, len(value), len(X))
+                    "%d; expected %d." % (key, len(value), len(X),)
                 )
         return self
 

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -29,7 +29,7 @@ BOUNDS_THRESHOLD = 1e-7
 
 
 def _handle_zeros_in_scale(scale: np.ndarray, copy=True):
-    """ Makes sure that whenever scale is zero, we handle it correctly.
+    """Makes sure that whenever scale is zero, we handle it correctly.
 
     This happens in most scalers when we have constant features."""
 
@@ -1036,12 +1036,12 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
 
 class PolynomialFeatures(sklearn.preprocessing.PolynomialFeatures):
-    """    preserve_dataframe : boolean
-            If True, preserve pandas and dask dataframes after transforming.
-            Using False (default) returns numpy or dask arrays and mimics
-            sklearn's default behaviour
+    """preserve_dataframe : boolean
+        If True, preserve pandas and dask dataframes after transforming.
+        Using False (default) returns numpy or dask arrays and mimics
+        sklearn's default behaviour
 
-        Examples
+    Examples
     """
 
     splitted_orig_doc = sklearn.preprocessing.PolynomialFeatures.__doc__.split(

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -307,7 +307,7 @@ def _log_array(logger, arr, name):
 
 def _format_bytes(n):
     # TODO: just import from distributed if / when required
-    """ Format bytes as text
+    """Format bytes as text
 
     >>> format_bytes(1)
     '1 B'

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -43,6 +43,22 @@ def svd_flip(u, v):
 svd_flip.__doc__ = skm.svd_flip.__doc__
 
 
+def flip_vector_signs(x, axis):
+    """ Flip vector signs to align them for comparison
+
+    Parameters
+    ----------
+    x : 2D array_like
+        Matrix containing vectors in rows or columns
+    axis : int, 0 or 1
+        Axis in which vectors reside
+    """
+    assert x.ndim == 2
+    signs = np.sum(x, axis=axis, keepdims=True)
+    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
+    return x * signs
+
+
 def slice_columns(X, columns):
     if isinstance(X, dd.DataFrame):
         return X[list(X.columns) if columns is None else columns]

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -517,8 +517,7 @@ class Incremental(ParallelPostFit):
 
 
 def _first_block(dask_object):
-    """Extract the first block / partition from a dask object
-    """
+    """Extract the first block / partition from a dask object"""
     if isinstance(dask_object, da.Array):
         if dask_object.ndim > 1 and dask_object.numblocks[-1] != 1:
             raise NotImplementedError(

--- a/tests/test_impute.py
+++ b/tests/test_impute.py
@@ -8,6 +8,7 @@ import sklearn.impute
 
 import dask_ml.datasets
 import dask_ml.impute
+from dask_ml._compat import DASK_2_26_0
 from dask_ml.utils import assert_estimator_equal
 
 rng = np.random.RandomState(0)
@@ -108,6 +109,9 @@ def test_frame_strategies(daskify, strategy):
     b.fit(df)
     if not daskify and strategy == "median":
         expected = pd.Series([1.5], index=["A"])
+    elif daskify and strategy == "median" and DASK_2_26_0:
+        # New quantile implementation in Dask
+        expected = pd.Series([1.0], index=["A"])
     else:
         expected = pd.Series([2], index=["A"])
     tm.assert_series_equal(b.statistics_, expected, check_dtype=False)

--- a/tests/test_incremental_pca.py
+++ b/tests/test_incremental_pca.py
@@ -6,6 +6,7 @@ from sklearn import datasets, decomposition as sd
 from sklearn.decomposition import PCA
 
 from dask_ml.decomposition import IncrementalPCA
+from dask_ml.utils import flip_vector_signs
 
 try:
     from sklearn.utils._testing import assert_almost_equal
@@ -33,7 +34,11 @@ def test_compare_with_sklearn(svd_solver, batch_number):
         n_components=2, batch_size=batch_size, svd_solver=svd_solver
     )
     ipca_da.fit(X_da)
-    np.testing.assert_allclose(ipca.components_, ipca_da.components_, atol=1e-13)
+    np.testing.assert_allclose(
+        flip_vector_signs(ipca.components_, 1),
+        flip_vector_signs(ipca_da.components_, 1),
+        atol=1e-13,
+    )
     np.testing.assert_allclose(
         ipca.explained_variance_, ipca_da.explained_variance_, atol=1e-13
     )

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -99,7 +99,6 @@ def test_pca_randomized_solver():
     )
 
 
-@pytest.mark.xfail(reason="tsqr expects n_samples>n_features")
 def test_no_empty_slice_warning():
     # test if we avoid numpy warnings for computing over empty arrays
     n_components = 10
@@ -278,7 +277,6 @@ def test_singular_values():
     )
 
 
-@pytest.mark.xfail(reason="Too wide")
 def test_singular_values_wide():
     # This is split off test_singular_values, but we can't pass it ATM
     # Set the singular values and see what we get back

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -104,6 +104,9 @@ def test_pca_randomized_solver():
 
 
 def test_no_empty_slice_warning():
+    if not DASK_2_26_0:
+        # See https://github.com/dask/dask/pull/6591
+        pytest.xfail("Dask SVD with wide arrays not supported until 2.26.0")
     # test if we avoid numpy warnings for computing over empty arrays
     n_components = 10
     n_features = n_components + 2  # anything > n_comps triggered it in 0.16
@@ -282,6 +285,9 @@ def test_singular_values():
 
 
 def test_singular_values_wide():
+    if not DASK_2_26_0:
+        # See https://github.com/dask/dask/pull/6591
+        pytest.xfail("Dask SVD with wide arrays not supported until 2.26.0")
     # This is split off test_singular_values, but we can't pass it ATM
     # Set the singular values and see what we get back
     rng = np.random.RandomState(0)

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -8,7 +8,7 @@ from sklearn import decomposition as sd
 from sklearn.utils import check_random_state
 
 from dask_ml import decomposition as dd
-from dask_ml.utils import assert_estimator_equal
+from dask_ml.utils import assert_estimator_equal, flip_vector_signs
 
 # Make an X that looks somewhat like a small tf-idf matrix.
 # XXX newer versions of SciPy have scipy.sparse.rand for this.
@@ -21,22 +21,6 @@ X.data[:] = 1 + np.log(X.data)
 Xdense = X.A
 
 dXdense = da.from_array(Xdense, chunks=(30, 55))
-
-
-def flip_vector_signs(x, axis):
-    """ Flip vector signs to align them for comparison
-
-    Parameters
-    ----------
-    x : 2D array_like
-        Matrix containing vectors in rows or columns
-    axis : int, 0 or 1
-        Axis in which vectors reside
-    """
-    assert x.ndim == 2
-    signs = np.sum(x, axis=axis, keepdims=True)
-    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
-    return x * signs
 
 
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])


### PR DESCRIPTION
This is a partial fix for https://github.com/dask/dask-ml/issues/736.

I think this is probably the best approach: https://github.com/dask/dask-ml/compare/master...eric-czech:svd_flip?expand=1#diff-151bb55aba85377c700e75a189fa2256

That only fixes TruncatedSVD at the moment, but it seems like a reasonable way to account for the differences now.  A function like `flip_vector_signs` could be applied to PCA components, loadings or scores to point all the vectors in the same direction before comparing them.  I'll go forward with that and try to fix as much as I can in the current build unless you would prefer something else @TomAugspurger.

FYI this PR also removes several xfail cases that now work for short-fat arrays.