### PR TITLE
Fixing sign stability in incremental PCA

### DIFF
--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -22,6 +22,7 @@ DASK_240 = DASK_VERSION >= packaging.version.parse("2.4.0")
 DASK_2130 = DASK_VERSION >= packaging.version.parse("2.13.0")
 DASK_2_20_0 = DASK_VERSION >= packaging.version.parse("2.20.0")
 DASK_2_26_0 = DASK_VERSION >= packaging.version.parse("2.26.0")
+DASK_2_28_0 = DASK_VERSION >= packaging.version.parse("2.28.0")
 DISTRIBUTED_2_5_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.5.0")
 DISTRIBUTED_2_11_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.10.0")  # dev
 WINDOWS = os.name == "nt"

--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -22,7 +22,7 @@ DASK_240 = DASK_VERSION >= packaging.version.parse("2.4.0")
 DASK_2130 = DASK_VERSION >= packaging.version.parse("2.13.0")
 DASK_2_20_0 = DASK_VERSION >= packaging.version.parse("2.20.0")
 DASK_2_26_0 = DASK_VERSION >= packaging.version.parse("2.26.0")
-DASK_2_28_0 = DASK_VERSION >= packaging.version.parse("2.28.0")
+DASK_2_28_0 = DASK_VERSION > packaging.version.parse("2.27.0")
 DISTRIBUTED_2_5_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.5.0")
 DISTRIBUTED_2_11_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.10.0")  # dev
 WINDOWS = os.name == "nt"

--- a/dask_ml/utils.py
+++ b/dask_ml/utils.py
@@ -33,8 +33,8 @@ def _svd_flip_copy(x, y, u_based_decision=True):
         return skm.svd_flip(x.copy(), y.copy(), u_based_decision=u_based_decision)
 
 
-def svd_flip(u, v):
-    u2, v2 = delayed(_svd_flip_copy, nout=2)(u, v)
+def svd_flip(u, v, u_based_decision=True):
+    u2, v2 = delayed(_svd_flip_copy, nout=2)(u, v, u_based_decision=u_based_decision)
     u = da.from_delayed(u2, shape=u.shape, dtype=u.dtype)
     v = da.from_delayed(v2, shape=v.shape, dtype=v.dtype)
     return u, v

--- a/tests/test_incremental_pca.py
+++ b/tests/test_incremental_pca.py
@@ -228,9 +228,10 @@ def test_incremental_pca_num_features_change():
 
 
 @pytest.mark.filterwarnings("ignore:invalid value:RuntimeWarning")
-def test_incremental_pca_batch_signs():
+@pytest.mark.parametrize("seed", [1999, 32, 831])
+def test_incremental_pca_batch_signs(seed):
     # Test that components_ sign is stable over batch sizes.
-    rng = np.random.RandomState(1999)
+    rng = np.random.RandomState(seed)
     n_samples = 100
     n_features = 3
     X = rng.randn(n_samples, n_features)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -803,13 +803,14 @@ def test_pca_sklearn_inputs(input_type, solver):
         a.fit_transform(Y)
 
 
-def test_svd_flip():
+@pytest.mark.parametrize("u_based", [True, False])
+def test_svd_flip(u_based):
     rng = np.random.RandomState(0)
     u = rng.randn(8, 3)
     v = rng.randn(3, 10)
     u = da.from_array(u, chunks=(-1, -1))
     v = da.from_array(v, chunks=(-1, -1))
-    u2, v2 = svd_flip(u, v)
+    u2, v2 = svd_flip(u, v, u_based_decision=u_based)
 
     def set_readonly(x):
         x.setflags(write=False)
@@ -817,6 +818,6 @@ def test_svd_flip():
 
     u = u.map_blocks(set_readonly)
     v = v.map_blocks(set_readonly)
-    u, v = svd_flip(u, v)
+    u, v = svd_flip(u, v, u_based_decision=u_based)
     assert_eq(u, u2)
     assert_eq(v, v2)

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -23,6 +23,22 @@ Xdense = X.A
 dXdense = da.from_array(Xdense, chunks=(30, 55))
 
 
+def flip_vector_signs(x, axis):
+    """ Flip vector signs to align them for comparison
+
+    Parameters
+    ----------
+    x : 2D array_like
+        Matrix containing vectors in rows or columns
+    axis : int, 0 or 1
+        Axis in which vectors reside
+    """
+    assert x.ndim == 2
+    signs = np.sum(x, axis=axis, keepdims=True)
+    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
+    return x * signs
+
+
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_basic(algorithm):
     a = dd.TruncatedSVD(random_state=0, algorithm=algorithm)

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -23,22 +23,6 @@ Xdense = X.A
 dXdense = da.from_array(Xdense, chunks=(30, 55))
 
 
-def flip_vector_signs(x, axis):
-    """ Flip vector signs to align them for comparison
-
-    Parameters
-    ----------
-    x : 2D array_like
-        Matrix containing vectors in rows or columns
-    axis : int, 0 or 1
-        Axis in which vectors reside
-    """
-    assert x.ndim == 2
-    signs = np.sum(x, axis=axis, keepdims=True)
-    signs = signs.dtype.type(2) * ((signs >= 0) - signs.dtype.type(0.5))
-    return x * signs
-
-
 @pytest.mark.parametrize("algorithm", ["tsqr", "randomized"])
 def test_basic(algorithm):
     a = dd.TruncatedSVD(random_state=0, algorithm=algorithm)


### PR DESCRIPTION
Hey @TomAugspurger, this includes some small changes to address the wrinkle I mentioned at https://github.com/dask/dask-ml/pull/737#issuecomment-692959949.  The "u vs v" choice in `svd_flip` does depend on whether or not you plan on using the right or left singular vectors and there is no way (I can find) to correct them both simultaneously.  Ideally, all PCA functions use a "v-based" correction since the principal components are equivalent to the right singular vectors.  I chose the "u-based" correction as the default in dask though, since that's what sklearn does, which leads to the somewhat awkward scenario at this level where you have to skip the correction in dask and then apply a similar one.

It would be most convenient for this project (and what we're trying to do) if a "v-based" correction was the default.  I added that in https://github.com/dask/dask/pull/6658 and wanted to point that out here.  That would obviate the need for any kind of svd-related sign correction in dask-ml after the next dask release.

FYI: The code before my changes was using `sklearn.svd_flip.u_based_decision=False` only for incremental pca to get the stability in signs that all PCA functions should probably have.  I can't see any reason why that shouldn't be what we do across the board.