### PR TITLE
Update pairwise check for scikit-learn 0.24

### DIFF
--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -197,7 +197,7 @@ def build_cv_graph(
     X, y, groups = to_indexable(X, y, groups)
     cv = check_cv(cv, y, is_classifier(estimator))
     # "pairwise" estimators require a different graph for CV splitting
-    is_pairwise = getattr(estimator, "_pairwise", False)
+    is_pairwise = estimator._get_tags().get("_pairwise", False)
 
     dsk = {}
     X_name, y_name, groups_name = to_keys(dsk, X, y, groups)

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -35,7 +35,7 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _num_samples
 
-from .._compat import SK_VERSION, check_is_fitted
+from .._compat import SK_VERSION, SK_024, check_is_fitted
 from ._normalize import normalize_estimator
 from .methods import (
     MISSING,
@@ -197,7 +197,10 @@ def build_cv_graph(
     X, y, groups = to_indexable(X, y, groups)
     cv = check_cv(cv, y, is_classifier(estimator))
     # "pairwise" estimators require a different graph for CV splitting
-    is_pairwise = estimator._get_tags().get("_pairwise", False)
+    if SK_024:
+        is_pairwise = estimator._get_tags().get("_pairwise", False)
+    else:
+        is_pairwise = getattr(estimator, "_pairwise", False)
 
     dsk = {}
     X_name, y_name, groups_name = to_keys(dsk, X, y, groups)

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -35,7 +35,7 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _num_samples
 
-from .._compat import SK_VERSION, SK_024, check_is_fitted
+from .._compat import SK_024, SK_VERSION, check_is_fitted
 from ._normalize import normalize_estimator
 from .methods import (
     MISSING,


### PR DESCRIPTION
Over in https://github.com/dask/dask-ml/pull/754 I ran across a `FutureWarning` in the scikit-learn dev build which caused CI to fail. The `estimator._pairwise` attribute was deprecated in https://github.com/scikit-learn/scikit-learn/pull/18143 in favor of using the `"pairwise"` key in the estimator's tags dictionary. 