### PR TITLE
#386 LogisticRegression.predict_proba should return (n, 2) for binary

### DIFF
--- a/dask_ml/linear_model/glm.py
+++ b/dask_ml/linear_model/glm.py
@@ -15,6 +15,7 @@ from sklearn.base import BaseEstimator
 
 from ..metrics import r2_score
 from ..utils import check_array
+from .utils import lr_prob_stack
 
 _base_doc = textwrap.dedent(
     """\
@@ -228,7 +229,7 @@ class LogisticRegression(_GLM):
 
         Returns
         -------
-        T : array-like, shape = [n_samples, n_classes]
+        T : array-like, shape = [n_samples,]
             The confidence score of the sample for each class in the model.
         """
         X_ = self._check_array(X)
@@ -246,7 +247,7 @@ class LogisticRegression(_GLM):
         C : array, shape = [n_samples,]
             Predicted class labels for each sample
         """
-        return self.predict_proba(X) > 0.5  # TODO: verify, multi_class broken
+        return self.predict_proba(X)[:, 1] > 0.5  # TODO: verify, multi_class broken
 
     def predict_proba(self, X):
         """Probability estimates for samples in X.
@@ -260,7 +261,9 @@ class LogisticRegression(_GLM):
         T : array-like, shape = [n_samples, n_classes]
             The probability of the sample for each class in the model.
         """
-        return sigmoid(self.decision_function(X))
+        # TODO: more work needed here to support multi_class
+        prob = sigmoid(self.decision_function(X))
+        return lr_prob_stack(prob)
 
     def score(self, X, y):
         """The mean accuracy on the given data and labels

--- a/dask_ml/linear_model/utils.py
+++ b/dask_ml/linear_model/utils.py
@@ -59,3 +59,13 @@ def add_intercept(X):  # noqa: F811
     if "intercept" in columns:
         raise ValueError("'intercept' column already in 'X'")
     return X.assign(intercept=1)[["intercept"] + list(columns)]
+
+
+@dispatch(np.ndarray)  # noqa: F811
+def lr_prob_stack(prob):  # noqa: F811
+    return np.vstack([1 - prob, prob]).T
+
+
+@dispatch(da.Array)  # noqa: F811
+def lr_prob_stack(prob):  # noqa: F811
+    return da.vstack([1 - prob, prob]).T

--- a/tests/linear_model/test_glm.py
+++ b/tests/linear_model/test_glm.py
@@ -193,3 +193,11 @@ def test_dataframe_warns_about_chunks(fit_intercept):
     clf.fit(X.values, y.values)
     clf.fit(X.to_dask_array(), y.to_dask_array())
     clf.fit(X.to_dask_array(lengths=True), y.to_dask_array(lengths=True))
+
+
+def test_logistic_predict_proba_shape():
+    X, y = make_classification(n_samples=100, n_features=5, chunks=50)
+    lr = LogisticRegression()
+    lr.fit(X, y)
+    prob = lr.predict_proba(X)
+    assert prob.shape == (100, 2)


### PR DESCRIPTION
This PR addresses #386 by making sure `LogisticRegression.predict_proba()` returns an array of shape `(n, 2)` to match what scikit-learn does. There are some things currently hard-coded for binary classification only, but it is clear that multi-class is currently not supported so that can be changed when multi-class is implemented.

There is some risk here that if users have downstream code that depends on the current functionality (return shape of `(n,)`), the changes from this PR could break their code. 