### PR TITLE
Fix CI for deploying docs

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -33,5 +33,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: docs/_build/html
+          FOLDER: docs/build/html
           CLEAN: true


### PR DESCRIPTION
Our built docs are put in `build/html`

https://github.com/dask/dask-ml/blob/cdd954d7a2d7f60ed50cddab788a1b30955f1baf/docs/Makefile#L9

However, our CI to deploy docs us attempting to deploy `_build/html`

https://github.com/dask/dask-ml/blob/cdd954d7a2d7f60ed50cddab788a1b30955f1baf/.github/workflows/ci-docs.yaml#L36

This PR updates our documentation GitHub action to ensure we use the correct directory 

EDIT: Closes https://github.com/dask/dask-ml/issues/790