### PR TITLE
Dask annotations compatibility

### DIFF
--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -23,8 +23,10 @@ DASK_2130 = DASK_VERSION >= packaging.version.parse("2.13.0")
 DASK_2_20_0 = DASK_VERSION >= packaging.version.parse("2.20.0")
 DASK_2_26_0 = DASK_VERSION >= packaging.version.parse("2.26.0")
 DASK_2_28_0 = DASK_VERSION > packaging.version.parse("2.27.0")
+DASK_2021_02_0 = DASK_VERSION >= packaging.version.parse("2021.02.0")
 DISTRIBUTED_2_5_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.5.0")
 DISTRIBUTED_2_11_0 = DISTRIBUTED_VERSION > packaging.version.parse("2.10.0")  # dev
+DISTRIBUTED_2021_02_0 = DISTRIBUTED_VERSION >= packaging.version.parse("2021.02.0")
 PANDAS_1_2_0 = PANDAS_VERSION > packaging.version.parse("1.2.0")
 WINDOWS = os.name == "nt"
 
@@ -35,6 +37,8 @@ def dummy_context(*args: Any, **kwargs: Any):
     # https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext
     yield
 
+
+annotate = dask.annotate if DASK_2021_02_0 else dummy_context
 
 blockwise = da.blockwise
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -244,7 +244,7 @@ async def _fit(
         _models[ident] = model
         _scores[ident] = score
         _specs[ident] = spec
-        
+
     if DISTRIBUTED_2021_02_0:
         _models, _scores, _specs = dask.persist(_models, _scores, _specs)
     else:

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -25,7 +25,7 @@ from sklearn.model_selection import ParameterGrid, ParameterSampler
 from sklearn.utils import check_random_state
 from sklearn.utils.metaestimators import if_delegate_has_method
 
-from .._compat import check_is_fitted, dummy_context, DISTRIBUTED_2021_02_0, annotate
+from .._compat import DISTRIBUTED_2021_02_0, annotate, check_is_fitted, dummy_context
 from .._typing import ArrayLike, Int
 from .._utils import LoggingContext
 from ..wrappers import ParallelPostFit

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -25,7 +25,7 @@ from sklearn.model_selection import ParameterGrid, ParameterSampler
 from sklearn.utils import check_random_state
 from sklearn.utils.metaestimators import if_delegate_has_method
 
-from .._compat import check_is_fitted, dummy_context
+from .._compat import check_is_fitted, dummy_context, DISTRIBUTED_2021_02_0, annotate
 from .._typing import ArrayLike, Int
 from .._utils import LoggingContext
 from ..wrappers import ParallelPostFit
@@ -239,13 +239,18 @@ async def _fit(
     for ident, model in models.items():
         model = d_partial_fit(model, X_future, y_future, fit_params)
         score = d_score(model, X_test, y_test, scorer)
-        spec = d_partial_fit(model, X_future_2, y_future_2, fit_params)
+        with annotate(priority=-1):
+            spec = d_partial_fit(model, X_future_2, y_future_2, fit_params)
         _models[ident] = model
         _scores[ident] = score
         _specs[ident] = spec
-    _models, _scores, _specs = dask.persist(
-        _models, _scores, _specs, priority={tuple(_specs.values()): -1}
-    )
+        
+    if DISTRIBUTED_2021_02_0:
+        _models, _scores, _specs = dask.persist(_models, _scores, _specs)
+    else:
+        _models, _scores, _specs = dask.persist(
+            _models, _scores, _specs, priority={tuple(_specs.values()): -1}
+        )
     _models = {k: list(v.dask.values())[0] for k, v in _models.items()}
     _scores = {k: list(v.dask.values())[0] for k, v in _scores.items()}
     _specs = {k: list(v.dask.values())[0] for k, v in _specs.items()}
@@ -301,14 +306,19 @@ async def _fit(
                     model = d_partial_fit(model, X_future, y_future, fit_params)
                 score = d_score(model, X_test, y_test, scorer)
                 X_future, y_future = get_futures(start + k)
-                spec = d_partial_fit(model, X_future, y_future, fit_params)
+                with annotate(priority=-1):
+                    spec = d_partial_fit(model, X_future, y_future, fit_params)
                 _models[ident] = model
                 _scores[ident] = score
                 _specs[ident] = spec
 
-        _models2, _scores2, _specs2 = dask.persist(
-            _models, _scores, _specs, priority={tuple(_specs.values()): -1}
-        )
+        if DISTRIBUTED_2021_02_0:
+            _models2, _scores2, _specs2 = dask.persist(_models, _scores, _specs)
+        else:
+            _models2, _scores2, _specs2 = dask.persist(
+                _models, _scores, _specs, priority={tuple(_specs.values()): -1}
+            )
+
         _models2 = {
             k: v if isinstance(v, Future) else list(v.dask.values())[0]
             for k, v in _models2.items()


### PR DESCRIPTION
The 2021.02.0 Dask / Distributed release updated how `priority=`, `resources=`, etc. keywords are handled (xref https://github.com/dask/distributed/pull/4406). This PR adds compatibility code to ensure that we use the new annotation system when using newer versions of Dask and Distributed. 

For reference, it looks like the CI failures here are due to unrelated `mypy` issuse which are being handled in https://github.com/dask/dask-ml/pull/786