### PR TITLE
TST Fixes random seed for flaky test_keras

### DIFF
--- a/tests/model_selection/test_keras.py
+++ b/tests/model_selection/test_keras.py
@@ -46,7 +46,9 @@ def _keras_build_fn(lr=0.01):
 @gen_cluster(client=True, Worker=Nanny, timeout=20)
 def test_keras(c, s, a, b):
     # Mirror the mnist dataset
-    X, y = make_classification(n_classes=10, n_features=784, n_informative=100)
+    X, y = make_classification(
+        n_classes=10, n_features=784, n_informative=100, random_state=0
+    )
     X = X.astype("float32")
     assert y.dtype == np.dtype("int64")
 
@@ -56,7 +58,12 @@ def test_keras(c, s, a, b):
     params = {"lr": loguniform(1e-3, 1e-1)}
 
     search = IncrementalSearchCV(
-        model, params, max_iter=3, n_initial_parameters=5, decay_rate=None
+        model,
+        params,
+        max_iter=3,
+        n_initial_parameters=5,
+        decay_rate=None,
+        random_state=0,
     )
     yield search.fit(X, y)
     #  search.fit(X, y)


### PR DESCRIPTION
Follow up to #794

I suspect the failing test on `main` is due to sampling of the parameter space that may lead to scores that are constant.

CC @stsievert 