### PR TITLE
fix testing dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ test_requires = [
     "flake8",
     "isort",
     "pytest",
-    "pytest-cover",
+    "pytest-cov",
     "pytest-mock",
 ]
 dev_requires = doc_requires + test_requires


### PR DESCRIPTION
Looking through the codebase today, I noticed that `setup.py` includes a dependency on a package `pytest-cover`.

That package's most recent release was in July 2015 ([PyPI page](https://pypi.org/project/pytest-cover/)), and after that point it was merged into `pytest-cov`. Based on that information and the fact that several environment files in this repo refer to `pytest-cov` (e.g. https://github.com/dask/dask-ml/blob/c964587bedd9abf29cb3065369ccf9f437c8e3eb/ci/environment-3.8.yaml#L23), I think `pytest-cov` is the intended dependency for `dask-ml`'s tests.

This PR proposes switching that `setup.py` entry to `pytest-cov`.