### PR TITLE
fix typos

### DIFF
--- a/dask_ml/_utils.py
+++ b/dask_ml/_utils.py
@@ -80,7 +80,7 @@ class LoggingContext:
             self.old_level = self.logger.level
             self.logger.setLevel(self.level)
 
-        # The reasonsing behind the last part of the below if statement:
+        # The reasoning behind the last part of the below if statement:
         # What if this context is called multiple times with the same logger?
         # Then, only add loggers if they have different output streams
         if self.handler and not any(

--- a/dask_ml/cluster/k_means.py
+++ b/dask_ml/cluster/k_means.py
@@ -86,7 +86,7 @@ class KMeans(TransformerMixin, BaseEstimator):
         A dask array with the index position in ``cluster_centers_`` this
         sample belongs to.
 
-    intertia_ : float
+    inertia_ : float
         Sum of distances of samples to their closest cluster center.
 
     n_iter_ : int

--- a/dask_ml/compose/_column_transformer.py
+++ b/dask_ml/compose/_column_transformer.py
@@ -114,7 +114,7 @@ boolean mask array or callable
         objects.
 
     sparse_output_ : boolean
-        Boolean flag indicating wether the output of ``transform`` is a
+        Boolean flag indicating whether the output of ``transform`` is a
         sparse matrix or a dense numpy array, which depends on the output
         of the individual transformers and the `sparse_threshold` keyword.
 

--- a/dask_ml/datasets.py
+++ b/dask_ml/datasets.py
@@ -408,9 +408,9 @@ def make_classification_df(
     response_rate : float between 0.0 and 0.5, default is 0.5
         percentage of sample to be response records max is 0.5
     predictability : float between 0.0 and 1.0, default is 0.1
-        how hard is the response to predict (1.0 being easist)
+        how hard is the response to predict (1.0 being easiest)
     random_state : int, default is None
-        seed for reproducability purposes
+        seed for reproducibility purposes
     chunks : int
         How to chunk the array. Must be one of the following forms:
         -   A blocksize like 1000.

--- a/dask_ml/decomposition/truncated_svd.py
+++ b/dask_ml/decomposition/truncated_svd.py
@@ -96,7 +96,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
 
         .. warning::
 
-           The implementation currently does not support sparse matricies.
+           The implementation currently does not support sparse matrices.
 
         Examples
         --------
@@ -115,7 +115,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         >>> print(svd.singular_values_)  # doctest: +ELLIPSIS
         array([35.92469517, 35.32922121, 34.53368856, 34.138..., 34.013...])
 
-        Note that ``tranform`` returns a ``dask.Array``.
+        Note that ``transform`` returns a ``dask.Array``.
 
         >>> svd.transform(X)
         dask.array<sum-agg, shape=(1000, 5), dtype=float64, chunksize=(100, 5)>
@@ -174,7 +174,7 @@ class TruncatedSVD(BaseEstimator, TransformerMixin):
         X = self._check_array(X)
         if self.algorithm not in {"tsqr", "randomized"}:
             raise ValueError(
-                "`algorithm` must be 'tsqr' or 'randomzied', not '{}'".format(
+                "`algorithm` must be 'tsqr' or 'randomized', not '{}'".format(
                     self.algorithm
                 )
             )

--- a/dask_ml/ensemble/_blockwise.py
+++ b/dask_ml/ensemble/_blockwise.py
@@ -177,7 +177,7 @@ class BlockwiseVotingClassifier(ClassifierMixin, BlockwiseBase):
         if isinstance(X, da.Array):
             chunks = (len(self.estimators_), X.chunks[0], len(self.classes_))
             meta = np.array([], dtype="float64")
-            # (n_estimators, len(X), n_classses)
+            # (n_estimators, len(X), n_classes)
             combined = X.map_blocks(
                 _predict_proba_stack,
                 estimators=self.estimators_,

--- a/dask_ml/feature_extraction/text.py
+++ b/dask_ml/feature_extraction/text.py
@@ -96,9 +96,9 @@ class HashingVectorizer(_BaseHasher, sklearn.feature_extraction.text.HashingVect
 
         Notes
         -----
-        The returned dask Array is composed scipy sparse matricies. If you need
+        The returned dask Array is composed scipy sparse matrices. If you need
         to compute on the result immediately, you may need to convert the individual
-        blocks to ndarrays or pydata/sparse matricies.
+        blocks to ndarrays or pydata/sparse matrices.
 
         >>> import sparse
         >>> X.map_blocks(sparse.COO.from_scipy_sparse, dtype=X.dtype)  # doctest: +SKIP
@@ -130,7 +130,7 @@ class CountVectorizer(sklearn.feature_extraction.text.CountVectorizer):
     Additionally, this implementation benefits from having
     an active ``dask.distributed.Client``, even on a single machine.
     When a client is present, the learned ``vocabulary`` is persisted
-    in distributed memory, which saves some recompuation and redundant
+    in distributed memory, which saves some recomputation and redundant
     communication.
 
     See Also

--- a/dask_ml/linear_model/glm.py
+++ b/dask_ml/linear_model/glm.py
@@ -178,7 +178,7 @@ class _GLM(BaseEstimator):
 
         Returns
         -------
-        self : objectj
+        self : object
         """
         X = self._check_array(X)
 

--- a/dask_ml/model_selection/_hyperband.py
+++ b/dask_ml/model_selection/_hyperband.py
@@ -256,7 +256,7 @@ class HyperbandSearchCV(BaseIncrementalSearchCV):
         the Hyperband model selection algorithm.
 
     best_score_ : float
-        Score achieved by ``best_estimator_`` on the vaidation set after the
+        Score achieved by ``best_estimator_`` on the validation set after the
         final call to ``partial_fit``.
 
     best_index_ : int

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -892,7 +892,7 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
         retained by the "inverse decay" algorithm.
 
     best_score_ : float
-        Score achieved by ``best_estimator_`` on the vaidation set after the
+        Score achieved by ``best_estimator_`` on the validation set after the
         final call to ``partial_fit``.
 
     best_index_ : int
@@ -956,7 +956,7 @@ class IncrementalSearchCV(BaseIncrementalSearchCV):
 
     For example, setting ``tol=0`` and ``patience=2`` means training will stop
     after two consecutive calls to ``model.partial_fit`` without improvement,
-    or when ``max_iter`` total calls to ``model.parital_fit`` are reached.
+    or when ``max_iter`` total calls to ``model.partial_fit`` are reached.
 
     """
 
@@ -1205,7 +1205,7 @@ class InverseDecaySearchCV(IncrementalSearchCV):
         Higher `decay_rate` will result in lower training times, at the cost
         of worse models.
 
-        The default ``decay_rate=1.0`` is chosen because it has some theoritical
+        The default ``decay_rate=1.0`` is chosen because it has some theoretical
         motivation [1]_.
 
     Attributes
@@ -1255,7 +1255,7 @@ class InverseDecaySearchCV(IncrementalSearchCV):
         retained by the "inverse decay" algorithm.
 
     best_score_ : float
-        Score achieved by ``best_estimator_`` on the vaidation set after the
+        Score achieved by ``best_estimator_`` on the validation set after the
         final call to ``partial_fit``.
 
     best_index_ : int
@@ -1278,7 +1278,7 @@ class InverseDecaySearchCV(IncrementalSearchCV):
     Notes
     -----
     When ``decay_rate==1``, this class approximates the
-    number of ``partial_fit`` calls that :class:`SuccesiveHalvingSearchCV`
+    number of ``partial_fit`` calls that :class:`SuccessiveHalvingSearchCV`
     performs. If ``n_initial_parameters`` is configured properly with
     ``decay_rate=1``, it's possible this class will mirror the most aggressive
     bracket of :class:`HyperbandSearchCV`. This might yield good results

--- a/dask_ml/model_selection/_split.py
+++ b/dask_ml/model_selection/_split.py
@@ -368,7 +368,7 @@ def train_test_split(
     convert_mixed_types=False,
     **options,
 ):
-    """Split arrays into random train and test matricies.
+    """Split arrays into random train and test matrices.
 
     Parameters
     ----------
@@ -396,7 +396,7 @@ def train_test_split(
 
     convert_mixed_types : bool, default False
         Whether to convert dask DataFrames and Series to dask Arrays when
-        arrays contains a mixiture of types. This results in some computation
+        arrays contains a mixture of types. This results in some computation
         to determine the length of each block.
 
     Returns
@@ -420,7 +420,7 @@ def train_test_split(
            [ 0.99439439, -0.70972797, -0.27567053,  1.73887268]])
     """
     if train_size is None and test_size is None:
-        # all other validation dones elsewhere.
+        # all other validation done elsewhere.
         test_size = 0.1
 
     if train_size is None and test_size is not None:

--- a/dask_ml/model_selection/_successive_halving.py
+++ b/dask_ml/model_selection/_successive_halving.py
@@ -165,7 +165,7 @@ class SuccessiveHalvingSearchCV(IncrementalSearchCV):
         retained by the "inverse decay" algorithm.
 
     best_score_ : float
-        Score achieved by ``best_estimator_`` on the vaidation set after the
+        Score achieved by ``best_estimator_`` on the validation set after the
         final call to ``partial_fit``.
 
     best_index_ : int
@@ -281,7 +281,7 @@ def _simulate_sha(n, r, eta, max_iter=None):
     Parameters
     ----------
     n : int
-        Number of intial models
+        Number of initial models
     r : int
         Number of initial calls
     eta : int

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -204,7 +204,7 @@ def _encode_categorical(
     if uniques is not None:
         diff = list(np.setdiff1d(uniques, new_uniques, assume_unique=True))
         if diff:
-            raise ValueError("y comtains previously unseen labels: {}".format(diff))
+            raise ValueError("y contains previously unseen labels: {}".format(diff))
 
     uniques = new_uniques
 
@@ -258,7 +258,7 @@ def _encode_dask_array(
     Parameters
     ----------
     values : da.Array, shape [n_samples,]
-    unqiques : np.ndarray, shape [n_uniques,]
+    uniques : np.ndarray, shape [n_uniques,]
     encode : bool, default False
         Whether to encode the values (True) or just discover the uniques.
     onehot_dtype : np.dtype, optional
@@ -278,7 +278,7 @@ def _encode_dask_array(
     uniques : ndarray
         The discovered uniques (uniques=None) or just `uniques`
     encoded : da.Array, optional
-        The encoded values. Only returend when ``encode=True``.
+        The encoded values. Only returned when ``encode=True``.
     """
 
     if uniques is None:

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -322,7 +322,7 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
             return _predict_proba(X, estimator=self._postfit_estimator)
 
     def predict_log_proba(self, X):
-        """Log of proability estimates.
+        """Log of probability estimates.
 
         For dask inputs, a dask array or dataframe is returned. For other
         inputs (NumPy array, pandas dataframe, scipy sparse matrix), the
@@ -394,7 +394,7 @@ class Incremental(ParallelPostFit):
     Parameters
     ----------
     estimator : Estimator
-        Any object supporting the scikit-learn ``parital_fit`` API.
+        Any object supporting the scikit-learn ``partial_fit`` API.
 
     scoring : string or callable, optional
         A single string (see :ref:`scoring_parameter`) or a callable

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -73,7 +73,7 @@ Version 1.1.0
 - Non-arrays (e.g. Dask Bags and DataFrames) are now allowed in :class:`dask_ml.wrappers.Incremental`. This is useful for text classification pipelines (pr:`570`)
 - The index is now preserved in :class:`dask_ml.preprocessing.PolynomialFeatures` for DataFrame inputs (:pr:`563`)
 - :class:`dask_ml.decomposition.PCA` now works with DataFrame inputs (:pr:`543`)
-- :class:`dask_ml.cluster.KMeans` handles inputes where some blocks are length-0 (:pr:`559`)
+- :class:`dask_ml.cluster.KMeans` handles inputs where some blocks are length-0 (:pr:`559`)
 - Improved error reporting for mixed inputs to :func:`dask_ml.model_selection.train_test_split` (:pr:`552`)
 - Removed deprecated ``dask_ml.joblib`` module. Use ``joblib.parallel_backend`` instead (:pr:`545`)
 - :class:`dask_ml.preprocessing.QuantileTransformer` now handles DataFrame input (:pr:`533`)
@@ -115,7 +115,7 @@ Note that this version of Dask-ML requires scikit-learn >= 0.20.0.
 Enhancements
 ------------
 
-- Added :class:`dask_ml.model_selection.IncrementalSearchCV`, a meta-estimator for hyperparamter optimization on larger-than-memory datasets (:pr:`356`). See :ref:`hyperparameter.incremental` for more.
+- Added :class:`dask_ml.model_selection.IncrementalSearchCV`, a meta-estimator for hyperparameter optimization on larger-than-memory datasets (:pr:`356`). See :ref:`hyperparameter.incremental` for more.
 - Added :class:`dask_ml.preprocessing.PolynomialTransformer`, a drop-in replacement for the scikit-learn version (:issue:`347`).
 - Added auto-rechunking to Dask Arrays with more than one block along the features in :class:`dask_ml.model_selection.ParallelPostFit` (:issue:`376`)
 - Added support for Dask DataFrame inputs to :class:`dask_ml.cluster.KMeans` (:issue:`390`)

--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -3,7 +3,7 @@
 Hyper Parameter Search
 ======================
 
-*Tools to perform hyperparameter optimizaiton of Scikit-Learn API-compatible
+*Tools to perform hyperparameter optimization of Scikit-Learn API-compatible
 models using Dask, and to scale hyperparameter optimization to* **larger
 data and/or larger searches.**
 
@@ -234,7 +234,7 @@ Dask-ML implements drop-in replacements for
    dask_ml.model_selection.GridSearchCV
    dask_ml.model_selection.RandomizedSearchCV
 
-The varians in Dask-ML implement many (but not all) of the same parameters,
+The variants in Dask-ML implement many (but not all) of the same parameters,
 and should be a drop-in replacement for the subset that they do implement.
 In that case, why use Dask-ML's versions?
 

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -39,7 +39,7 @@ Incremental Meta-estimator
 takes another estimator) that bridges scikit-learn estimators expecting
 NumPy arrays, and users with large Dask Arrays.
 
-Each *block* of a Dask Array is fed to the underlying estiamtor's
+Each *block* of a Dask Array is fed to the underlying estimator's
 ``partial_fit`` method. The training is entirely sequential, so you won't
 notice massive training time speedups from parallelism. In a distributed
 environment, you should notice some speedup from avoiding extra IO, and the
@@ -74,7 +74,7 @@ for you.
 
 Just like :meth:`sklearn.linear_model.SGDClassifier.partial_fit`, we need to
 pass the ``classes`` argument to ``fit``. In general, any argument that is
-required for the underlying estimators ``parital_fit`` becomes required for
+required for the underlying estimators ``partial_fit`` becomes required for
 the wrapped ``fit``.
 
 
@@ -95,7 +95,7 @@ We can get the accuracy score on our dataset.
 
    clf.score(X, y)
 
-All of the attributes learned durning training, like ``coef_``, are available
+All of the attributes learned during training, like ``coef_``, are available
 on the ``Incremental`` instance.
 
 .. ipython:: python

--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -206,13 +206,13 @@ Meta-estimators for building composite models with transformers.
 .. currentmodule:: dask_ml
 
 .. autosummary::
-   :toctree: generted/
+   :toctree: generated/
    :template: class.rst
 
    compose.ColumnTransformer
 
 .. autosummary::
-   :toctree: generted/
+   :toctree: generated/
 
    compose.make_column_transformer
 

--- a/docs/source/preprocessing.rst
+++ b/docs/source/preprocessing.rst
@@ -96,10 +96,10 @@ The default behavior of OneHotEncoder is to return a sparse array. Scikit-Learn
 returns a SciPy sparse matrix for ndarrays passed to ``transform``.
 
 When passed a Dask Array, :meth:`OneHotEncoder.transform` returns a Dask Array
-*where each block is a scipy sparse matrix*. SciPy sparse matricies don't
+*where each block is a scipy sparse matrix*. SciPy sparse matrices don't
 support the same API as the NumPy ndarray, so most methods won't work on the
 result. Even basic things like ``compute`` will fail. To work around this,
-we currently recommend converting the sparse matricies to dense.
+we currently recommend converting the sparse matrices to dense.
 
 .. code-block:: python
 
@@ -120,7 +120,7 @@ Each block of ``result`` is a scipy sparse matrix
    result.blocks[0].compute()
    # This would fail!
    # result.compute()
-   # Convert to, say, pydata/sparse COO matricies instead
+   # Convert to, say, pydata/sparse COO matrices instead
    from sparse import COO
 
    result.map_blocks(COO.from_scipy_sparse, dtype=result.dtype).compute()

--- a/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
@@ -106,7 +106,7 @@ def test_hyperparameter_searcher_with_fit_params(cls, kwargs):
     pipe = Pipeline([("clf", clf)])
     searcher = cls(pipe, {"clf__foo_param": [1, 2, 3]}, cv=2, **kwargs)
 
-    # The CheckingClassifer generates an assertion error if
+    # The CheckingClassifier generates an assertion error if
     # a parameter is missing or has length != len(X).
     with pytest.raises(AssertionError) as exc:
         searcher.fit(X, y, clf__spam=np.ones(10))
@@ -310,7 +310,7 @@ def test_no_refit():
     assert not hasattr(grid_search, "best_score_")
     assert not hasattr(grid_search, "best_params_")
 
-    # Make sure the predict/transform etc fns raise meaningfull error msg
+    # Make sure the predict/transform etc fns raise meaningful error msg
     for fn_name in (
         "predict",
         "predict_proba",

--- a/tests/model_selection/test_hyperband.py
+++ b/tests/model_selection/test_hyperband.py
@@ -304,7 +304,7 @@ def test_correct_params(c, s, a, b):
 
 def test_params_passed():
     # This makes sure that the "SuccessiveHalvingSearchCV params" key in
-    # Hyperband.metadata["brackets"] is correct and they can be instatiated.
+    # Hyperband.metadata["brackets"] is correct and they can be instantiated.
     est = ConstantFunction(value=0.4)
     params = {"value": np.linspace(0, 1)}
     params = {

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -472,7 +472,7 @@ def test_small(c, s, a, b):
 
 @gen_cluster(client=True)
 def test_smaller(c, s, a, b):
-    # infininte loop
+    # infinite loop
     X, y = make_classification(n_samples=100, n_features=5, chunks=(10, 5))
     model = SGDClassifier(tol=1e-3, penalty="elasticnet")
     params = {"alpha": [0.1, 0.5]}

--- a/tests/model_selection/test_successive_halving.py
+++ b/tests/model_selection/test_successive_halving.py
@@ -29,7 +29,7 @@ def test_basic_successive_halving(c, s, a, b):
 @pytest.mark.parametrize("r", [2, 3])
 @pytest.mark.parametrize("n", [9, 22])
 def test_sha_max_iter_and_metadata(n, r):
-    # This test makes sure the number of partial fit calls is perserved
+    # This test makes sure the number of partial fit calls is preserved
     # when
 
     # * n_initial_parameters and max_iter are specified

--- a/tests/preprocessing/test_data.py
+++ b/tests/preprocessing/test_data.py
@@ -121,7 +121,7 @@ class TestMinMaxScaler:
         mask = ["3", "4"]
         a = dpp.MinMaxScaler(columns=mask)
         result = a.inverse_transform(a.fit_transform(df2))
-        assert dask.is_dask_colelction(result)
+        assert dask.is_dask_collection(result)
         assert_eq_df(result, df2)
 
     def test_df_values(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,7 +204,7 @@ def test_check_array_1d():
                 dd.from_pandas(pd.Series([1, 2, 3]), 2),
                 dd.from_pandas(pd.Series([1, 2, 3]), 2).reset_index(),
             ],
-            marks=pytest.mark.xfail(reason="Known and unknown divisiosn."),
+            marks=pytest.mark.xfail(reason="Known and unknown divisions."),
         ),
     ],
 )


### PR DESCRIPTION
I've been trying to get familiar with `dask-ml` recently and find little ways to contribute. As part of that, I spent a little time tonight looking for typos. Typos in the repo can lead to false negatives in search, which might make it a little more difficult to navigate the code / docs.

I searched for these using `aspell`, like:

```shell
find . -type f -name "*.py" -exec cat {} \; \
    | aspell list \
    | sort -u 
```

That leads to a lot of things that aren't really typos, but a few looked like legitimate mistakes that should be fixed. This PR proposes fixing them.

Thanks for your time and consideration.