### PR TITLE
Make all references to sklearn.utils.validation.check_is_fitted uniform

### DIFF
--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 from collections.abc import Mapping  # noqa
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import dask
 import dask.array as da

--- a/dask_ml/_compat.py
+++ b/dask_ml/_compat.py
@@ -43,12 +43,6 @@ annotate = dask.annotate if DASK_2021_02_0 else dummy_context
 blockwise = da.blockwise
 
 
-def check_is_fitted(est, attributes: Optional[Union[str, List[str]]] = None):
-    args: Any = ()
-
-    return sklearn.utils.validation.check_is_fitted(est, *args)
-
-
 def _check_multimetric_scoring(estimator, scoring=None):
     # TODO: See if scikit-learn 0.24 solves the need for using
     # a private method

--- a/dask_ml/cluster/k_means.py
+++ b/dask_ml/cluster/k_means.py
@@ -10,8 +10,9 @@ import sklearn.cluster
 from dask import compute
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.extmath import squared_norm
+from sklearn.utils.validation import check_is_fitted
 
-from .._compat import SK_024, blockwise, check_is_fitted
+from .._compat import SK_024, blockwise
 from .._utils import draw_seed
 from ..metrics import (
     euclidean_distances,

--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -7,9 +7,9 @@ import numpy as np
 import sklearn.decomposition
 from dask import compute, delayed
 from sklearn.utils.extmath import fast_logdet
-from sklearn.utils.validation import check_random_state
+from sklearn.utils.validation import check_is_fitted, check_random_state
 
-from .._compat import DASK_2_26_0, check_is_fitted
+from .._compat import DASK_2_26_0
 from .._utils import draw_seed
 from ..utils import svd_flip
 

--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -24,8 +24,9 @@ from sklearn.metrics import check_scoring
 from sklearn.model_selection import ParameterGrid, ParameterSampler
 from sklearn.utils import check_random_state
 from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils.validation import check_is_fitted
 
-from .._compat import DISTRIBUTED_2021_02_0, annotate, check_is_fitted, dummy_context
+from .._compat import DISTRIBUTED_2021_02_0, annotate, dummy_context
 from .._typing import ArrayLike, Int
 from .._utils import LoggingContext
 from ..wrappers import ParallelPostFit

--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -33,9 +33,9 @@ from sklearn.model_selection._split import (
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.multiclass import type_of_target
-from sklearn.utils.validation import _num_samples
+from sklearn.utils.validation import _num_samples, check_is_fitted
 
-from .._compat import SK_024, SK_VERSION, check_is_fitted
+from .._compat import SK_024, SK_VERSION
 from ._normalize import normalize_estimator
 from .methods import (
     MISSING,

--- a/dask_ml/model_selection/_successive_halving.py
+++ b/dask_ml/model_selection/_successive_halving.py
@@ -3,8 +3,8 @@ import math
 
 import numpy as np
 import toolz
+from sklearn.utils.validation import check_is_fitted
 
-from .._compat import check_is_fitted
 from ._incremental import IncrementalSearchCV
 
 

--- a/dask_ml/preprocessing/data.py
+++ b/dask_ml/preprocessing/data.py
@@ -15,9 +15,9 @@ from dask.array import nanmean, nanvar
 from pandas.api.types import is_categorical_dtype
 from scipy import stats
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_random_state
+from sklearn.utils.validation import check_is_fitted, check_random_state
 
-from dask_ml._compat import blockwise, check_is_fitted
+from dask_ml._compat import blockwise
 from dask_ml._utils import copy_learned_attributes
 from dask_ml.utils import check_array, handle_zeros_in_scale
 

--- a/dask_ml/preprocessing/label.py
+++ b/dask_ml/preprocessing/label.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import scipy.sparse
 import sklearn.preprocessing
+from sklearn.utils.validation import check_is_fitted
 
-from .._compat import check_is_fitted
 from .._typing import ArrayLike, SeriesType
 
 

--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -7,10 +7,10 @@ import dask.delayed
 import numpy as np
 import sklearn.base
 import sklearn.metrics
+from sklearn.utils.validation import check_is_fitted
 
 from dask_ml.utils import _timer
 
-from ._compat import check_is_fitted
 from ._partial import fit
 from ._utils import copy_learned_attributes
 from .metrics import check_scoring, get_scorer


### PR DESCRIPTION
**Associated GitHub Issue(s):** N/A
**Tests/`black`/`pyflakes` passing:** Yes
**Tests added:** No

I've noticed that `check_is_fitted` is referenced differently from a couple of files in the `dask-ml` codebase.

The majority (8 vs 2) of the references are `from .._compat import check_is_fitted`.

This PR proposes unifying the references (i.e., updating the remaining 2) for the sake of future-proofing, with respect to any potential updates in the behavior of `dask_ml/compat.py`.