### PR TITLE
Temporarily restrict dask version in CI

### DIFF
--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -6,9 +6,12 @@ dependencies:
   - black==19.10b0
   - coverage
   - codecov
-  - dask
+  # dask 2021.3.0 introduced a regression which causes tests to fail.
+  # The issue has been resolved upstream in dask and will be included
+  # in the next release. We temporarily apply a dask version contraint
+  # to allow CI to pass
+  - dask !=2021.3.0
   - dask-glm >=0.2.0
-  - distributed
   - flake8
   - isort==4.3.21
   - multipledispatch >=0.4.9

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -6,9 +6,12 @@ dependencies:
   - black==19.10b0
   - coverage
   - codecov
-  - dask
+  # dask 2021.3.0 introduced a regression which causes tests to fail.
+  # The issue has been resolved upstream in dask and will be included
+  # in the next release. We temporarily apply a dask version contraint
+  # to allow CI to pass
+  - dask !=2021.3.0
   - dask-glm >=0.2.0
-  - distributed
   - flake8
   - isort==4.3.21
   - multipledispatch >=0.4.9

--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -38,9 +38,12 @@ dependencies:
   - xgboost
   - zict
   - pip
-  - dask
+  # dask 2021.3.0 introduced a regression which causes tests to fail.
+  # The issue has been resolved upstream in dask and will be included
+  # in the next release. We temporarily apply a dask version contraint
+  # to allow CI to pass
+  - dask !=2021.3.0
   - dask-glm
-  - distributed
   - dask-xgboost
   - pip:
     - dask_sphinx_theme >=1.1.0


### PR DESCRIPTION
It looks like the `dask=2021.3.0` introduced a regression which is causing tests here to fail (see [a recent CI build on the `main` branch](https://dev.azure.com/dask-dev/dask/_build/results?buildId=1983&view=logs&j=ec4c5d99-1a39-52ae-ac68-aabdfb55b8a0&t=fc02acdf-e905-55f3-d38f-f279841d296b)). Locally I tested against the latest `main` branch of `dask` and the issue seems to be resolved.

This PR temporarily applies a version constraint to `dask` in CI to get tests to pass. We should revert the changes here after the next `dask` release. 