### PR TITLE
Require numba>=0.51.0 (#802)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
 install_requires = [
     "dask[array,dataframe]>=2.4.0",
     "distributed>=2.4.0",
-    "numba",
+    "numba>=0.51.0",
     "numpy>=1.17.3",
     "pandas>=0.24.2",
     "scikit-learn>=0.23",


### PR DESCRIPTION
- **Associated GitHub Issue(s):** https://github.com/dask/dask-ml/issues/802.
- **Tests/`black`/`pyflakes` passing:** Yes.
- **Tests added:** No.
- **Description:** We saw over at #802 that due to a discrepancy in the underlying `numba` version, some unexpected behavior was observed. This PR proposes a minimum version requirement for `numba`, namely `0.51.0`, which is the earliest one, not enabling `dask-ml` to exhibit correct, expected behavior.