### PR TITLE
[docs] replace dask-lightgbm reference with LightGBM

### DIFF
--- a/docs/source/xgboost.rst
+++ b/docs/source/xgboost.rst
@@ -22,8 +22,8 @@ classes/functions:
    XGBClassifier
    XGBRegressor
 
-The LightGBM implementation and documentation can be found at
-https://github.com/dask/dask-lightgbm.
+The LightGBM implementation can be found at https://github.com/microsoft/LightGBM and documentation can be found at
+https://lightgbm.readthedocs.io/en/latest/Parallel-Learning-Guide.html#dask.
 
 Example
 -------


### PR DESCRIPTION
Following the discussion in https://github.com/dask/community/issues/104, the maintainers of `dask-lightgbm` agreed to upstream that project into `LightGBM`: https://github.com/microsoft/LightGBM/pull/3515.

This week, the first version of `LightGBM` that includes a Dask interface was released.

* https://pypi.org/project/lightgbm/
* https://github.com/microsoft/LightGBM/releases/tag/v3.2.0

Now that the LightGBM Dask integration has been released, this PR proposes removing references to `dask-lightgbm` and replacing them with references to LightGBM.

## Other Related Work

I've also opened https://github.com/dask/dask-lightgbm/pull/30, proposing that `dask-lightgbm` do one more release that raises a warning directing users to `LightGBM`.