### PR TITLE
Ensure consistent Python version in docs CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Documentation
 on: [push, pull_request]
 
 jobs:
@@ -12,7 +12,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: "3.7"
           environment-file: ci/environment-docs.yaml
           activate-environment: dask-ml-docs
           auto-activate-base: false

--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -24,7 +24,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - python=3.9
+  - python=3.8
   - sortedcontainers
   - scikit-learn>=0.23.1
   - scipy

--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -24,7 +24,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - python=3.8
+  - python=3.7
   - sortedcontainers
   - scikit-learn>=0.23.1
   - scipy

--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -24,7 +24,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - python=3.6.6
+  - python=3.9
   - sortedcontainers
   - scikit-learn>=0.23.1
   - scipy


### PR DESCRIPTION
Previously we were specifying the Python version for our documentation build in two places: our GitHub actions workflow and the corresponding conda environment file. This PR switches to just using the conda environment file to avoid using inconsistent Python versions, which can lead to CI failures. 