### PR TITLE
Update README and documentation index page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Dask-ML
 
 |Build Status| |Azure Pipelines| |Coverage| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
 
-Dask-ML provides scalable machine learning in Python using `Dask <https://dask.org/>`__ alongside popular machine learning libraries like `Scikit-Learn <http://scikit-learn.org/>`__, `XGBoost <https://xgboost.readthedocs.io/>`__, and others.
+Dask-ML provides scalable machine learning in Python using `Dask <https://dask.org/>`__ alongside popular machine learning libraries like `Scikit-Learn <http://scikit-learn.org/>`__, `XGBoost <https://ml.dask.org/xgboost.html>`__, and others.
 
 You can try Dask-ML on a small cloud instance by clicking the following button:
 

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,35 @@
-dask-ml
+Dask-ML
 =======
 
-``dask-ml`` is a library for distributed and parallel machine learning using `dask`_.
-See the `documentation`_ for more.
+|Build Status| |Azure Pipelines| |Coverage| |Doc Status| |Gitter| |Version Status| |NumFOCUS|
 
-.. image:: https://dev.azure.com/dask-dev/dask/_apis/build/status/dask.dask-ml?branchName=main
+Dask-ML provides scalable machine learning in Python using `Dask <https://dask.org/>`__ alongside popular machine learning libraries like `Scikit-Learn <http://scikit-learn.org/>`__, `XGBoost <https://xgboost.readthedocs.io/>`__, and others.
+
+You can try Dask-ML on a small cloud instance by clicking the following button:
+
+.. image:: https://mybinder.org/badge.svg
+   :target: https://mybinder.org/v2/gh/dask/dask-examples/main?filepath=machine-learning.ipynb
+
+LICENSE
+-------
+
+New BSD. See `License File <https://github.com/dask/dask-ml/blob/main/LICENSE.txt>`__.
+
+.. _documentation: https://dask.org
+.. |Build Status| image:: https://github.com/dask/dask-ml/workflows/CI/badge.svg?branch=main
+   :target: https://github.com/dask/dask-ml/actions?query=workflow%3A%22CI%22
+.. |Azure Pipelines| image:: https://dev.azure.com/dask-dev/dask/_apis/build/status/dask.dask-ml?branchName=main
    :target: https://dev.azure.com/dask-dev/dask/_build/latest?definitionId=1&branchName=main
-   :alt: CI Status
-
-.. _dask: https://dask.org
-.. _documentation: http://ml.dask.org
+.. |Coverage| image:: https://codecov.io/gh/dask/dask-ml/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/dask/dask-ml/branch/main
+   :alt: Coverage status
+.. |Doc Status| image:: https://readthedocs.org/projects/ml/badge/?version=latest
+   :target: https://ml.dask.org/
+   :alt: Documentation Status
+.. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
+   :alt: Join the chat at https://gitter.im/dask/dask
+   :target: https://gitter.im/dask/dask?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |Version Status| image:: https://img.shields.io/pypi/v/dask-ml.svg
+   :target: https://pypi.python.org/pypi/dask-ml/
+.. |NumFOCUS| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+   :target: https://www.numfocus.org/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Dask-ML
 =======
 
 Dask-ML provides scalable machine learning in Python using Dask_ alongside
-popular machine learning libraries like Scikit-Learn_, XGBoost, and others.
+popular machine learning libraries like Scikit-Learn_, XGBoost_, and others.
 
 You can try Dask-ML on a small cloud instance by clicking the following button:
 
@@ -132,3 +132,4 @@ See :doc:`Dask-ML + XGBoost <xgboost>` for more information.
 
 .. _Dask: https://dask.org/
 .. _Scikit-Learn: http://scikit-learn.org/
+.. _XGBoost: https://xgboost.readthedocs.io/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -132,4 +132,4 @@ See :doc:`Dask-ML + XGBoost <xgboost>` for more information.
 
 .. _Dask: https://dask.org/
 .. _Scikit-Learn: http://scikit-learn.org/
-.. _XGBoost: https://xgboost.readthedocs.io/
+.. _XGBoost: https://ml.dask.org/xgboost.html


### PR DESCRIPTION
README preview [here](https://github.com/hristog/dask-ml/blob/update-readme-and-doc-index/README.rst).

Apparently, the Codecov report is still pointing at the `master` branch (Update: I've just raised https://github.com/dask/dask-ml/issues/817 for that to be addressed under, if needs be). The [Codecov settings](https://app.codecov.io/gh/dask/dask-ml/settings) need to be updated accordingly (requires maintainer access, unless the target brach could be set up from elsewhere).

The badges are set to point to `main`.

Update: https://github.com/dask/dask-ml/issues/817 has been closed as done.