### PR TITLE
fix typo in CI config

### DIFF
--- a/ci/posix.yaml
+++ b/ci/posix.yaml
@@ -10,13 +10,13 @@ jobs:
     matrix:
       linux37:
         envFile: 'ci/environment-3.7.yaml'
-        SKLARN_DEV: "no"
+        SKLEARN_DEV: "no"
       linux38:
         envFile: 'ci/environment-3.8.yaml'
-        SKLARN_DEV: "no"
+        SKLEARN_DEV: "no"
       earliest:
         envFile: 'ci/environment-3.6.yaml'
-        SKLARN_DEV: "no"
+        SKLEARN_DEV: "no"
       sklearnDev:
         envFile: 'ci/environment-3.7.yaml'
         SKLEARN_DEV: "yes"


### PR DESCRIPTION
I noticed today, looking at the config for this project's CI jobs, that there is a typo in `ci/posix.yaml`. The variable `SKLEARN_DEV` is used to control whether or not the latest nightly build of `scikit-learn` should be installed. Several matrix items use the variable `SKLARN_DEV` (missing an "E").

This doesn't affect the jobs at all as far as I can tell, since not being set at all and being set to `"no"` should result in the same outcome from `eq(variables.SKLEARN_DEV, 'yes')`. But I still think it's worth fixing, just for the sake of correctness and greppability.