### PR TITLE
test multioutput for metrics.mean_squared_log_error()

### DIFF
--- a/tests/metrics/test_regression.py
+++ b/tests/metrics/test_regression.py
@@ -11,6 +11,7 @@ from dask_ml._compat import SK_024
 
 _METRICS_TO_TEST = [
     "mean_squared_error",
+    "mean_squared_log_error",
     "mean_absolute_error",
     "r2_score",
 ]
@@ -61,18 +62,6 @@ def test_mse_squared(squared):
 
     result = m1(a, b, squared=squared)
     expected = m2(a, b, squared=squared)
-    assert abs(result - expected) < 1e-5
-
-
-def test_mean_squared_log_error():
-    m1 = dask_ml.metrics.mean_squared_log_error
-    m2 = sklearn.metrics.mean_squared_log_error
-
-    a = da.random.uniform(size=(100,), chunks=(25,))
-    b = da.random.uniform(size=(100,), chunks=(25,))
-
-    result = m1(a, b)
-    expected = m2(a, b)
     assert abs(result - expected) < 1e-5
 
 


### PR DESCRIPTION
This PR proposes simplifying the current tests for regression metrics and expanding the test coverage of `mean_squared_log_error()`.

As of this PR, that metric function's behavior when `multioutput=None` and `multioutput="uniform_average"` would now be tested.