### PR TITLE
MAINT: raise error is no partial_fit in hyperparameter search

### DIFF
--- a/dask_ml/model_selection/_incremental.py
+++ b/dask_ml/model_selection/_incremental.py
@@ -166,6 +166,14 @@ async def _fit(
     models: Dict[int, Tuple[Model, Meta]] = {}
     scores: Dict[int, Meta] = {}
 
+    if "partial_fit" not in dir(model):
+        raise ValueError(
+            f"model={model} does not implement `partial_fit`, a "
+            "requirement for doing incremental hyperparameter "
+            "optimization. For more detail, see\n\n"
+            "    https://ml.dask.org/hyper-parameter-search.html#hyperparameter-scaling"
+        )
+
     logger.info("[CV%s] creating %d models", prefix, len(params))
     for ident, param in enumerate(params):
         model = client.submit(_create_model, original_model, ident, **param)

--- a/tests/model_selection/test_incremental.py
+++ b/tests/model_selection/test_incremental.py
@@ -22,7 +22,7 @@ from distributed.utils_test import (  # noqa: F401
 )
 from scipy.stats import uniform
 from sklearn.base import clone
-from sklearn.cluster import MiniBatchKMeans
+from sklearn.cluster import MiniBatchKMeans, KMeans
 from sklearn.linear_model import SGDClassifier
 from sklearn.model_selection import ParameterGrid, ParameterSampler
 from sklearn.utils import check_random_state
@@ -33,6 +33,7 @@ from dask_ml.model_selection import (
     HyperbandSearchCV,
     IncrementalSearchCV,
     InverseDecaySearchCV,
+    RandomizedSearchCV,
 )
 from dask_ml.model_selection._incremental import _partial_fit, _score, fit
 from dask_ml.model_selection.utils_test import LinearFunction, _MaybeLinearFunction
@@ -854,6 +855,24 @@ def test_warns_scores_per_fit(c, s, a, b):
     with pytest.warns(UserWarning, match="deprecated since Dask-ML v1.4.0"):
         yield search.fit(X, y)
 
+@gen_cluster(client=True)
+async def test_raises_if_no_partial_fit(c, s, a, b):
+    X, y = make_classification(n_samples=20, n_features=3, chunks=(10, -1))
+    X, y = await c.gather(c.compute([X, y]))
+    assert isinstance(X, np.ndarray)
+    assert isinstance(y, np.ndarray)
+
+    params = {"n_init": list(range(1, 10))}
+    model = KMeans(max_iter=5, verbose=1, algorithm="elkan")
+
+    search = IncrementalSearchCV(model, params)
+    with pytest.raises(ValueError, match="does not implement `partial_fit`"):
+        await search.fit(X, y)
+
+    # no partial_fit, but works with a passive search
+    search2 = RandomizedSearchCV(model, params, n_iter=2)
+    await search2.fit(X, y)
+    assert search2.best_score_
 
 @gen_cluster(client=True)
 async def test_model_future(c, s, a, b):


### PR DESCRIPTION
**What does this PR implement?**
It raises an error if a model is passed to an incremental hyperparameter optimization that doesn't support `partial_fit`. It points to https://ml.dask.org/hyper-parameter-search.html#hyperparameter-scaling.

It also tests to make sure that a passive search like `RandomizedSearchCV` works.

**Reference issues/PRs**
This resolves #839. It doesn't solve the issue, but it makes the error more clear.