### PR TITLE
Scatter estimator in ParallelPostFit

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -223,7 +223,8 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
             dt = _transform(xx, self._postfit_estimator).dtype
             return X.map_blocks(_transform, estimator=estimator_or_fut, dtype=dt)
         elif isinstance(X, dd._Frame):
-            return X.map_partitions(_transform, estimator=estimator_or_fut)
+            meta = self._postfit_estimator.transform(X.head(1, npartitions=-1))
+            return X.map_partitions(_transform, estimator=estimator_or_fut, meta=meta)
         else:
             return _transform(X, estimator=self._postfit_estimator)
 
@@ -334,7 +335,10 @@ class ParallelPostFit(sklearn.base.BaseEstimator, sklearn.base.MetaEstimatorMixi
                 chunks=(X.chunks[0], len(self._postfit_estimator.classes_)),
             )
         elif isinstance(X, dd._Frame):
-            return X.map_partitions(_predict_proba, estimator=estimator_or_fut)
+            meta = self._postfit_estimator.predict_proba(X.head(1, npartitions=-1))
+            return X.map_partitions(
+                _predict_proba, estimator=estimator_or_fut, meta=meta
+            )
         else:
             return _predict_proba(X, estimator=self._postfit_estimator)
 


### PR DESCRIPTION
closes #842 

Functionality of ParallelPostFit is the same, except behind the scenes it now scatters the scikit-learn estimator if running with a distributed cluster. Compared to existing functionality showcased in #842 where scheduler memory increases by npartitions * estimator size, the memory increase is now just estimator size for a quick blip while it gets shipped out to the workers

<img width="443" alt="Screen Shot 2021-07-02 at 1 21 26 PM" src="https://user-images.githubusercontent.com/8964039/124312972-38a93280-db3e-11eb-809d-babc4d9e050a.png">
