### PR TITLE
Unpin `dask` in documentation environment

### DIFF
--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -32,11 +32,7 @@ dependencies:
   - xgboost
   - zict
   - pip
-  # dask 2021.3.0 introduced a regression which causes tests to fail.
-  # The issue has been resolved upstream in dask and will be included
-  # in the next release. We temporarily apply a dask version contraint
-  # to allow CI to pass
-  - dask !=2021.3.0
+  - dask
   - dask-glm
   - dask-xgboost
   - pip:


### PR DESCRIPTION
This was pinned in https://github.com/dask/dask-ml/pull/807 but is no longer needed 