### PR TITLE
Add pytest color to CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ check_untyped_defs=False
 follow_imports=skip
 
 [tool:pytest]
-addopts = -rsx -v --durations=10
+addopts = -rsx -v --durations=10 --color=yes
 minversion = 3.2
 xfail_strict = true
 junit_family = xunit2


### PR DESCRIPTION
Similar to https://github.com/dask/dask/pull/8090 and https://github.com/dask/distributed/pull/5276. This will result in color coded output in CI (similar to what many folks see when running tests locally)