### PR TITLE
DOC: typo, `StandardScaler` listed twice in docs

### DIFF
--- a/docs/source/modules/api.rst
+++ b/docs/source/modules/api.rst
@@ -173,7 +173,6 @@ with Dask Arrays or DataFrames.
    preprocessing.RobustScaler
    preprocessing.MinMaxScaler
    preprocessing.QuantileTransformer
-   preprocessing.StandardScaler
    preprocessing.Categorizer
    preprocessing.DummyEncoder
    preprocessing.OrdinalEncoder


### PR DESCRIPTION
Got a little confused reading the docs until I realized `StandardScaler` is listed twice. Fixing it here!