### PR TITLE
RLS: 2016.11.16

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2021.11.16
+~~~~~~~~~~~~~~~~~~
+
+* Meta-estimators like :class:`wrappers.ParallelPostFit` now work with cuDF and CuPy objects. (:pr:`862`)
+* Fixed incompatibility with new Dask optimizations in :class:`wrappers.ParallelPostFit` (:pr:`878`) 
+
 Version 2021.10.17
 ~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "dask[array,dataframe]>=2.4.0",
     "distributed>=2.4.0",
     "numba>=0.51.0",
-    "numpy>=1.17.3",
+    "numpy>=1.20.0",
     "pandas>=0.24.2",
     "scikit-learn>=1.0.0",
     "scipy",


### PR DESCRIPTION
* Changelog
* Update requirements (#862 requires NumPy 1.20 for the new `like=` keyword)