### PR TITLE
Skip `_check_param_grid` import for scikit-learn > 1.0.2

### DIFF
--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -23,7 +23,7 @@ from sklearn.base import (
     is_classifier,
 )
 from sklearn.exceptions import NotFittedError
-from sklearn.model_selection._search import BaseSearchCV, _check_param_grid
+from sklearn.model_selection._search import BaseSearchCV
 from sklearn.model_selection._split import (
     BaseShuffleSplit,
     KFold,
@@ -70,6 +70,12 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = ["GridSearchCV", "RandomizedSearchCV"]
+
+# scikit-learn > 1.0.2 removed _check_param_grid
+if SK_VERSION <= packaging.version.parse("1.0.2"):
+    from sklearn.model_selection._search import _check_param_grid
+else:
+    _check_param_grid = None
 
 if SK_VERSION <= packaging.version.parse("0.21.dev0"):
 
@@ -1600,8 +1606,8 @@ class GridSearchCV(StaticDaskSearchMixin, DaskBaseSearchCV):
             n_jobs=n_jobs,
             cache_cv=cache_cv,
         )
-
-        _check_param_grid(param_grid)
+        if _check_param_grid:
+            _check_param_grid(param_grid)
         self.param_grid = param_grid
 
     def _get_param_iterator(self):

--- a/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
@@ -371,10 +371,15 @@ def test_grid_search_one_grid_point():
 
 
 def test_grid_search_bad_param_grid():
+    # passing a non-iterable param grid raises a TypeError in scikit-learn > 1.0.2
+    iterable_err = (
+        ValueError if SK_VERSION <= packaging.version.parse("1.0.2") else TypeError
+    )
+
     param_dict = {"C": 1.0}
     clf = SVC()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(iterable_err):
         dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
     param_dict = {"C": []}
@@ -386,7 +391,7 @@ def test_grid_search_bad_param_grid():
     param_dict = {"C": "1,2,3"}
     clf = SVC()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(iterable_err):
         dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
     param_dict = {"C": np.ones(6).reshape(3, 2)}

--- a/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
+++ b/tests/model_selection/dask_searchcv/test_model_selection_sklearn.py
@@ -375,24 +375,25 @@ def test_grid_search_bad_param_grid():
     clf = SVC()
 
     with pytest.raises(ValueError):
-        dcv.GridSearchCV(clf, param_dict)
+        dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
     param_dict = {"C": []}
     clf = SVC()
 
     with pytest.raises(ValueError):
-        dcv.GridSearchCV(clf, param_dict)
+        dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
     param_dict = {"C": "1,2,3"}
     clf = SVC()
 
     with pytest.raises(ValueError):
-        dcv.GridSearchCV(clf, param_dict)
+        dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
     param_dict = {"C": np.ones(6).reshape(3, 2)}
     clf = SVC()
+
     with pytest.raises(ValueError):
-        dcv.GridSearchCV(clf, param_dict)
+        dcv.GridSearchCV(clf, param_dict)._get_param_iterator()
 
 
 def test_grid_search_sparse():


### PR DESCRIPTION
Attempting to resolve the breakage recorded in https://github.com/dask/dask-ml/issues/894