### PR TITLE
Fix precomputed kernel test with _safe_tags.

### DIFF
--- a/dask_ml/model_selection/_search.py
+++ b/dask_ml/model_selection/_search.py
@@ -15,12 +15,7 @@ from dask.delayed import delayed
 from dask.distributed import as_completed
 from dask.utils import derived_from
 from sklearn import model_selection
-from sklearn.base import (
-    BaseEstimator,
-    MetaEstimatorMixin,
-    clone,
-    is_classifier,
-)
+from sklearn.base import BaseEstimator, MetaEstimatorMixin, clone, is_classifier
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection._search import BaseSearchCV
 from sklearn.model_selection._split import (
@@ -36,7 +31,7 @@ from sklearn.model_selection._split import (
     _CVIterableWrapper,
 )
 from sklearn.pipeline import FeatureUnion, Pipeline
-from sklearn.utils.estimator_checks import _is_pairwise_metric
+from sklearn.utils._tags import _safe_tags
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _num_samples, check_is_fitted
@@ -94,7 +89,6 @@ if SK_VERSION <= packaging.version.parse("0.21.dev0"):
                 if key.endswith("_train_score"):
                     results.add_warning(key, message.format(key), FutureWarning)
         return results
-
 
 else:
     _RETURN_TRAIN_SCORE_DEFAULT = False
@@ -209,7 +203,7 @@ def build_cv_graph(
     X, y, groups = to_indexable(X, y, groups)
     cv = check_cv(cv, y, is_classifier(estimator))
     # "pairwise" estimators require a different graph for CV splitting
-    is_pairwise = _is_pairwise_metric(estimator)
+    is_pairwise = _safe_tags(estimator, "pairwise")
 
     dsk = {}
     X_name, y_name, groups_name = to_keys(dsk, X, y, groups)


### PR DESCRIPTION
@TomAugspurger sorry to bother you again.
I realized that one of the failures in #910 was indeed related to my changes.
The failure is related to #771 and its fix in  #772.
As the tag "pairwise" is not defined the test fails again.
I have replaced ``is_pairwise_metric`` with the ``_safe_tags()`` function (see [here](https://github.com/scikit-learn/scikit-learn/blob/e61040c14e59bec3b0d275d40a43e10cf641af32/sklearn/utils/_tags.py#L25)) which falls back to default when the tags is not defined.
Sorry for not noticing that before.