### PR TITLE
Allowing for models without built-in or custom scoring to be used

### DIFF
--- a/dask_ml/wrappers.py
+++ b/dask_ml/wrappers.py
@@ -556,7 +556,7 @@ class Incremental(ParallelPostFit):
         return self.estimator_
 
     def _fit_for_estimator(self, estimator, X, y, **fit_kwargs):
-        check_scoring(estimator, self.scoring)
+        check_scoring(estimator, self.scoring, allow_none=True)
         if not dask.is_dask_collection(X) and not dask.is_dask_collection(y):
             result = estimator.partial_fit(X=X, y=y, **fit_kwargs)
         else:


### PR DESCRIPTION
Hello,
I hope you are all doing well!

Currently, models that do not have built-in scoring cannot be used with dask_ml wrappers, unless custom scoring is specified. For example, using this code, taken mostly from the sklearn example [here](https://scikit-learn.org/stable/auto_examples/cluster/plot_birch_vs_minibatchkmeans.html#sphx-glr-auto-examples-cluster-plot-birch-vs-minibatchkmeans-py)

`import numpy as np
import dask.array as da
from sklearn.cluster import Birch
from dask_ml.wrappers import Incremental
from sklearn.datasets import make_blobs


# Generate centers for the blobs so that it forms a 10 X 10 grid.
xx = da.linspace(-22, 22, 10)
yy = da.linspace(-22, 22, 10)
xx, yy = da.meshgrid(xx, yy)
n_centers = da.hstack((da.ravel(xx)[:, np.newaxis], da.ravel(yy)[:, np.newaxis]))

# Generate blobs to do a comparison between MiniBatchKMeans and BIRCH.
X, y = make_blobs(n_samples=25000, centers=n_centers, random_state=0)
birch =  Birch(threshold=1.7, n_clusters=None)
inc = Incremental(birch)
inc.fit(X)
`

This code currently, raises a TypeError because: If no scoring is specified, the estimator passed should have a 'score' method. The estimator Birch(n_clusters=None, threshold=1.7) does not.

I fixed it by allowing for None when calling check_scoring within the fit method. If there is a reason to not allow a loosening of this check, I am open to other solutions. Other potential solutions I saw at a glance include:

1) adding a parameter to fit that propagates to the allow_none value of check_scoring - defaulted to False
2) removing the line, as I do not see scoring being used directly in _fit_for_estimator, and other areas of the code explicitly check for/handle scoring = None. 

All tests that utilize classes within dask_ml.wrapper pass.


Thanks!
Nick
