### PR TITLE
DOC Fix "non expected warning" and "non expected exception" sphinx errors.

### DIFF
--- a/docs/source/hyper-parameter-search.rst
+++ b/docs/source/hyper-parameter-search.rst
@@ -420,6 +420,7 @@ This section uses :class:`~dask_ml.model_selection.HyperbandSearchCV`, but it ca
 also be applied to to :class:`~dask_ml.model_selection.IncrementalSearchCV` too.
 
 .. ipython:: python
+   :okwarning:
 
     from dask.distributed import Client
     from dask_ml.datasets import make_classification

--- a/docs/source/incremental.rst
+++ b/docs/source/incremental.rst
@@ -48,6 +48,7 @@ between machines.
 
 
 .. ipython:: python
+   :okwarning:
 
    from dask_ml.datasets import make_classification
    from dask_ml.wrappers import Incremental

--- a/docs/source/meta-estimators.rst
+++ b/docs/source/meta-estimators.rst
@@ -56,7 +56,7 @@ This class is useful for predicting for or transforming large datasets.
 We'll make a larger dask array ``X_big`` with 10,000 samples per block.
 
 .. ipython:: python
-
+   :okwarning:
    X_big, _ = dask_ml.datasets.make_classification(n_samples=100000,
                                                    chunks=10000,
                                                    random_state=0)
@@ -68,7 +68,7 @@ cause the scheduler to compute tasks in parallel. If you've connected to a
 cluster of machines.
 
 .. ipython:: python
-
+   :okexcept:
    clf.predict_proba(X_big).compute()[:10]
 
 See `parallelizing prediction`_ for an example of how this

--- a/docs/source/naive-bayes.rst
+++ b/docs/source/naive-bayes.rst
@@ -19,6 +19,7 @@ Example
 -------
 
 .. ipython:: python
+   :okwarning:
 
    from dask_ml import datasets
    from dask_ml.naive_bayes import GaussianNB


### PR DESCRIPTION
This pull request fixes the "non expected warning" and "non expected exception" sphinx errors in the build of the documentation.
There are still other warnings but this fixes should allow the build process to complete.... at least this is the case on my local machine.

The `:okwarnings:` and `:okexception:` directives tell sphinx to ignore the warnings and exceptions related to "running on a single-machine scheduler when a distributed client is active" leading to unexpected results.