### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/ci/environment-docs.yaml
+++ b/ci/environment-docs.yaml
@@ -35,5 +35,5 @@ dependencies:
   - dask-glm
   - dask-xgboost
   - pip:
-    - dask_sphinx_theme >=1.1.0
+    - dask-sphinx-theme >=3.0.0
     - graphviz

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,9 @@ exclude_patterns = ["build", "**.ipynb_checkpoints"]
 exclude_trees = ["_build", "includes"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "default"
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell