### PR TITLE
Fix toctree to display "Get Started" section in the left sidebar

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,7 +89,10 @@ workflows to prepare and set up data, then it deploys XGBoost
 See :doc:`Dask-ML + XGBoost <xgboost>` for more information.
 
 
-.. toctree:: :maxdepth: 2 :hidden: :caption: Get Started
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Get Started
 
    install.rst
    examples.rst


### PR DESCRIPTION
Typo fixes to add some new lines. :)

After change:

<img width="269" alt="Screenshot 2022-06-19 at 5 14 20 AM" src="https://user-images.githubusercontent.com/33131404/174460328-ee0eeb53-6c57-4657-99f9-d582bafb1cb5.png">
