### PR TITLE
Implement make_s_curve

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -55,6 +55,7 @@ def test_make_regression():
         dask_ml.datasets.make_classification,
         dask_ml.datasets.make_counts,
         dask_ml.datasets.make_regression,
+        dask_ml.datasets.make_s_curve,
     ],
 )
 def test_deterministic(generator, scheduler):
@@ -80,3 +81,19 @@ def test_make_classification_df():
     assert len(X_df) == 100
     assert len(y_series) == 100
     assert isinstance(y_series, dask.dataframe.core.Series)
+
+
+def test_make_s_curve():
+    X, X_color = dask_ml.datasets.make_s_curve(
+        n_samples=200,
+        random_state=0,
+        chunks=100,
+    )
+
+    assert isinstance(X, da.Array)
+    assert X.shape == (200, 3)
+    assert X.compute().shape == X.shape
+
+    assert isinstance(X_color, da.Array)
+    assert X_color.shape == (200,)
+    assert X_color.compute().shape == X_color.shape


### PR DESCRIPTION
Hi everyone,

I have created a pull request that includes the implementation of a make_s_curve function and corresponding tests for it. However, one of the tests is currently failing consistently, even though I have verified the values in the outputs and the computation graph. I would greatly appreciate any feedback or suggestions on how to resolve this issue.

The test that failed.
`
@pytest.mark.parametrize(
    "generator",
    [
        dask_ml.datasets.make_blobs,
        dask_ml.datasets.make_classification,
        dask_ml.datasets.make_counts,
        dask_ml.datasets.make_regression,
        dask_ml.datasets.make_s_curve,
    ],
)
def test_deterministic(generator, scheduler):
    a, t = generator(chunks=100, random_state=10)
    b, u = generator(chunks=100, random_state=10)
    assert_eq(a, b)
    assert_eq(t, u)
`