### PR TITLE
Updated conditions on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,6 @@ jobs:
       contents: read
     name: Publish released package to pypi.org
     environment: release-pypi
-    if: github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: check-package
 


### PR DESCRIPTION
This `if` condition shouldn't be necessary. We only run this workflow on releases.