### PR TITLE
Fixed: stop using invalid .A attribute of scipy sparse matrix

### DIFF
--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -19,7 +19,7 @@ rng = check_random_state(42)
 X = rng.randint(-100, 20, np.product(shape)).reshape(shape)
 X = sp.csr_matrix(np.maximum(X, 0), dtype=np.float64)
 X.data[:] = 1 + np.log(X.data)
-Xdense = X.A
+Xdense = X.toarray()
 
 dXdense = da.from_array(Xdense, chunks=(30, 55))
 


### PR DESCRIPTION
This previously deprecated attribute has been definitly removed from scipy in the latest release (1.14.0).
It is equivalent to `.toarray()`.

https://github.com/scipy/scipy/blob/7750f15ffd026ab758bd9b720f3628b0284cb905/doc/source/release/1.14.0-notes.rst?plain=1#L225-L228