### PR TITLE
Fix upstream miniconda setup

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -40,9 +40,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict


### PR DESCRIPTION
This step is currently failing ([example build](https://github.com/dask/dask-ml/actions/runs/13201892757/job/36855660614)) with 

```
Run conda-incubator/setup-miniconda@v2
Gathering Inputs...
Creating bootstrap condarc file in /home/runner/.condarc...
Ensuring installer...
  Can we use bundled Miniconda?
  Can we download a custom installer by URL?
  Can we download Miniconda?
  Can we download Miniforge?
  ... will download Miniforge.
  Will fetch Mambaforge latest from https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
  Ensuring Installer...
  Checking for cached Mambaforge@latest...
  Did not find Mambaforge-Linux-x86_64.sh latest in cache
Error: Unexpected HTTP response: 404
```

Updating the `conda-incubator/setup-miniconda` and avoiding `mambaforge` (which I think was deprecated or removed?) should fix things. 