### PR TITLE
fix: prevent broadcasting errors in r2_score using da.where()

### DIFF
--- a/tests/metrics/test_regression.py
+++ b/tests/metrics/test_regression.py
@@ -116,3 +116,19 @@ def test_regression_metrics_do_not_support_weighted_multioutput(metric_pairs):
 
     with pytest.raises((NotImplementedError, ValueError), match=error_msg):
         _ = m1(a, b, multioutput=weights)
+
+
+def test_r2_score_with_different_chunk_patterns():
+    """Test r2_score with different chunking configurations."""
+    # Create arrays with compatible but different chunk patterns
+    a = da.random.uniform(size=(100,), chunks=25)  # 4 chunks
+    b = da.random.uniform(size=(100,), chunks=20)  # 5 chunks
+    result = dask_ml.metrics.r2_score(a, b)
+    assert isinstance(result, float)
+    # Create arrays with different chunk patterns
+    a_multi = da.random.uniform(size=(100, 3), chunks=(25, 3))  # 4 chunks
+    b_multi = da.random.uniform(size=(100, 3), chunks=(20, 3))  # 5 chunks
+    result_multi = dask_ml.metrics.r2_score(
+        a_multi, b_multi, multioutput="uniform_average"
+    )
+    assert isinstance(result_multi, float)


### PR DESCRIPTION
Closes https://github.com/dask/dask-ml/issues/1012

First PR here. Curious to hear your feedback.

**Problem**
After updating to Dask 2025.2.0, tests fail with a ValueError due to changes in chunk size handling.

**Solution**
Refactor r2_score() to use da.where() for correct broadcasting.

**Testing**
Test added to ensure r2_score() works correctly with arrays that have different chunk configurations.