### PR TITLE
Fix randomized PCA transform after fit

### DIFF
--- a/dask_ml/decomposition/pca.py
+++ b/dask_ml/decomposition/pca.py
@@ -193,6 +193,9 @@ class PCA(sklearn.decomposition.PCA):
         self.svd_solver = svd_solver
         self.tol = tol
         self.iterated_power = iterated_power
+        # scikit-learn's PCA.__sklearn_tags__ reads this attribute for
+        # randomized solvers when check_is_fitted calls get_tags.
+        self.power_iteration_normalizer = "auto"
         self.random_state = random_state
 
     def fit(self, X, y=None):

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -104,6 +104,17 @@ def test_pca_randomized_solver():
     )
 
 
+def test_pca_randomized_transform_after_fit():
+    pca = dd.PCA(n_components=2, svd_solver="randomized", random_state=0)
+
+    pca.fit(dX)
+    assert pca.power_iteration_normalizer == sd.PCA().power_iteration_normalizer
+
+    X_r = pca.transform(dX)
+    assert X_r.shape == (n_samples, 2)
+    X_r.compute()
+
+
 def test_no_empty_slice_warning():
     if not DASK_2_26_0:
         # See https://github.com/dask/dask/pull/6591


### PR DESCRIPTION
Fixes #1023

This PR fixes `dask_ml.decomposition.PCA.transform` after `fit` when `svd_solver="randomized"` is used with newer scikit-learn versions.

- Dask-ML's PCA subclasses sklearn's PCA, but its custom initializer did not define `power_iteration_normalizer`. 
- Newer sklearn tag logic reads this attribute inside `PCA.__sklearn_tags__`, which is reached by `check_is_fitted` during `transform`. 
- As a result, `fit(...).transform(...)` failed with an `AttributeError`.

The fix sets `power_iteration_normalizer` to sklearn's defualt value, `"auto"`, preserving current Dask-ML behavior while keeping the estimator compatible with sklearn's inherited tag logic.

added a regression test covering randomized PCA `fit` followed by `transform`.

tested:

```bash
python -m pytest tests/test_pca.py::test_pca_randomized_transform_after_fit tests/test_pca.py::test_pca_randomized_solver -q